### PR TITLE
security: validate Mapbox style URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   status and reset Mapbox follow mode after denial or revocation.
 - Added a tracked-file guard for public and secret Mapbox token formats without
   exposing matched values in checker output.
+- Rejected Mapbox style URL credentials, token query parameters, and incomplete
+  Mapbox owner/style paths while preserving credential-free HTTPS providers.
 
 ## 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Set `MAPBOX_ACCESS_TOKEN` in Xcode build settings or include the copied
 `engagement/MapboxSecrets.xcconfig` in your local configuration. Optionally set
 `MAPBOX_STYLE_URL` locally to use a custom Mapbox style; leave it blank to use
 Mapbox's default style. Local style URLs are limited to `mapbox` or `https`
-schemes. Keep real Mapbox tokens and private style URLs out of git. Set your
+schemes, must not embed Mapbox style URL credentials or `access_token` query
+parameters, and `mapbox://styles` values require owner and style path
+components. Keep real Mapbox tokens and private style URLs out of git. Set your
 Apple development team locally in Xcode when building for a device; the checked
 in project keeps `DEVELOPMENT_TEAM` blank.
 
@@ -97,6 +99,8 @@ in project keeps `DEVELOPMENT_TEAM` blank.
   Mapbox token formats while allowing the local placeholder template.
 - `make check` also requires configured Mapbox style URLs to use `mapbox` or
   `https` schemes with valid scheme-specific authorities.
+- `make check` also rejects Mapbox style URL credentials, `access_token` query
+  parameters, and incomplete `mapbox://styles/<owner>/<style>` paths.
 - GitHub Actions runs the same static `make check` baseline with Ruby 3.3,
   Node 24-compatible pinned actions, read-only permissions, disabled checkout
   credential persistence, and a timeout.
@@ -148,6 +152,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   binary integrity and explicit legacy-build boundary.
 - See `docs/plans/2026-06-10-mapbox-style-url-authority.md` for configured
   style URL authority validation.
+- See `docs/plans/2026-06-12-mapbox-style-url-credential-path-validation.md`
+  for credential-free style URLs and complete Mapbox owner/style paths.
 - See `docs/plans/2026-06-12-location-authorization-transitions.md` for the
   status-driven tracking transition contract.
 - See `docs/plans/2026-06-12-mapbox-secret-token-guard.md` for the tracked

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
   digest changes require explicit review and do not imply current SDK support.
 - Locally configured style URLs must include the expected Mapbox styles
   authority or a non-empty HTTPS host.
+- Mapbox style URL credentials and `access_token` query parameters are rejected;
+  Mapbox-scheme styles must include owner and style path components.
 - Each location authorization transition must apply the delegate-provided
   status directly and disable Mapbox follow mode when permission is unavailable.
 - Tracked non-vendored files are checked for public and secret Mapbox token formats;

--- a/VISION.md
+++ b/VISION.md
@@ -21,6 +21,8 @@ Priority:
 - Keep optional Mapbox style URLs in local configuration
 - Keep configured Mapbox style URLs limited to expected schemes
 - Keep configured style URLs bound to valid scheme-specific authorities
+- Keep Mapbox style URL credentials and token query parameters out of style
+  configuration, with complete owner/style paths for Mapbox-scheme URLs
 - Request visible location authorization before user-location tracking
 - Keep location authorization scoped to when-in-use foreground tracking
 - Enable Mapbox user tracking only after compatible authorization is available

--- a/docs/plans/2026-06-12-mapbox-style-url-credential-path-validation.md
+++ b/docs/plans/2026-06-12-mapbox-style-url-credential-path-validation.md
@@ -1,0 +1,86 @@
+# Mapbox Style URL Credential And Path Validation
+
+## Status: Completed
+
+## Context
+
+The archived app resolves an optional Mapbox style URL from local build
+configuration and already restricts it to `mapbox` or `https` with a valid
+authority. The helper still accepts embedded URL user information, explicit
+`access_token` query parameters, and incomplete values such as
+`mapbox://styles` without owner and style path components.
+
+## Priority
+
+Style URLs cross a network and credential boundary. The dedicated
+`MGLMapboxAccessToken` configuration should remain the only token channel, and
+accepted `mapbox://styles/...` values should identify a usable owner/style
+resource. These checks are local parsing changes and do not require reviving
+the legacy Mapbox or Xcode runtime.
+
+## Requirements
+
+- R1. Reject configured style URLs containing a username or password.
+- R2. Reject style URL queries containing an `access_token` parameter without
+  logging or exposing the value.
+- R3. Require `mapbox://styles/<owner>/<style>` to contain at least two
+  non-root path components.
+- R4. Preserve credential-free custom HTTPS style URLs with non-empty hosts.
+- R5. Preserve blank or unresolved configuration as default-style behavior.
+- R6. Extend the dependency-free checker and project documentation to keep the
+  credential and Mapbox path contracts fail closed.
+- R7. Protect user info, token queries, incomplete paths, accepted HTTPS URLs,
+  documentation, and plan completion with focused hostile mutations.
+
+## Scope Boundaries
+
+- Do not change the separately configured Mapbox access-token mechanism.
+- Do not log rejected URLs or credential values.
+- Do not restrict HTTPS styles to Mapbox-owned hosts; documented custom style
+  providers remain supported.
+- Do not rewrite history or dismiss the existing secret-scanning alert without
+  credential-owner revocation evidence.
+- Do not claim modern Mapbox or Xcode compatibility.
+
+## Verification Plan
+
+- `ruby scripts/check_ios_contract.rb`
+- `make check` locally, outside the checkout, and in a network-isolated Ruby
+  container
+- focused valid-Git-metadata mutations for every new URL boundary
+- workflow YAML, plist, asset JSON, SVG XML, and vendored-framework digest checks
+- Swift delimiter/source checks, secret screening, and `git diff --check`
+
+## Work Completed
+
+- Rejected style URLs containing URL usernames or passwords before Mapbox map
+  initialization.
+- Parsed URL query items and rejected case-insensitive `access_token` names so
+  the separate plist token setting remains the only supported credential path.
+- Required Mapbox-scheme style URLs to contain at least owner and style path
+  components after the `styles` authority.
+- Preserved credential-free custom HTTPS providers with non-empty hosts and the
+  existing blank/unresolved default-style behavior.
+- Extended the dependency-free checker, local configuration template, README,
+  security guidance, vision, and changelog with the new boundary.
+
+## Verification
+
+- `ruby scripts/check_ios_contract.rb` passed after implementation.
+- `make check` and root-independent `make -f /path/to/Makefile check` passed;
+  both reported the documented legacy Xcode skip because no compatible macOS
+  toolchain is installed.
+- A read-only, network-isolated Ruby 3.3 container at
+  `ruby@sha256:c5601aff6552fa869f3c09a4a804f284b5f46762af7de0d210f2f7081e0e9e96`
+  passed `make check` against an exact standalone Git snapshot.
+- Eleven focused valid-Git-metadata mutations were rejected: missing or partial
+  URL user-info checks, missing/case-sensitive/wrong token query checks,
+  missing or incomplete Mapbox paths, weakened HTTPS host and scheme controls,
+  missing security guidance, and incomplete-plan status.
+- Workflow YAML, three plists, seven asset JSON files, and two README SVG files
+  parsed successfully.
+- The vendored Mapbox executable matched `VENDORED_FRAMEWORKS.sha256`.
+- Swift delimiter checks, corrected PCRE2 high-confidence secret and Mapbox
+  token screening, and `git diff --check` passed.
+- Legacy Xcode compile, simulator, and device validation remain unavailable in
+  this Linux environment.

--- a/engagement/MapboxSecrets.xcconfig.example
+++ b/engagement/MapboxSecrets.xcconfig.example
@@ -1,4 +1,4 @@
 // Copy to MapboxSecrets.xcconfig and keep the real file out of git.
 MAPBOX_ACCESS_TOKEN = replace-with-mapbox-public-token
-// Optional. Leave blank for Mapbox's default style or set a local mapbox/https style URL.
+// Optional. Leave blank for Mapbox's default style or set a credential-free local mapbox/https style URL.
 MAPBOX_STYLE_URL =

--- a/engagement/ViewController.swift
+++ b/engagement/ViewController.swift
@@ -119,8 +119,21 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
             return nil
         }
 
+        guard styleURL.user == nil, styleURL.password == nil else {
+            return nil
+        }
+
+        if let queryItems = URLComponents(url: styleURL, resolvingAgainstBaseURL: false)?.queryItems,
+           queryItems.contains(where: { $0.name.lowercased() == "access_token" }) {
+            return nil
+        }
+
         if styleURLScheme == "mapbox" {
             guard styleURL.host?.lowercased() == "styles" else {
+                return nil
+            }
+            let stylePathComponents = styleURL.pathComponents.filter { $0 != "/" }
+            guard stylePathComponents.count >= 2 else {
                 return nil
             }
         } else {

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -236,6 +236,9 @@ end
   unless document.include?('Mapbox token formats')
     failures << "#{doc_path} must document the tracked Mapbox token format guard"
   end
+  unless document.include?('Mapbox style URL credentials')
+    failures << "#{doc_path} must document the Mapbox style URL credential boundary"
+  end
 end
 
 view_controller = File.read('engagement/ViewController.swift')
@@ -264,6 +267,17 @@ unless view_controller.include?('let allowedStyleURLSchemes = ["mapbox", "https"
 end
 unless view_controller.include?('styleURL.host?.lowercased() == "styles"')
   failures << 'ViewController.swift must require the styles authority for mapbox style URLs'
+end
+unless view_controller.include?('guard styleURL.user == nil, styleURL.password == nil')
+  failures << 'ViewController.swift must reject embedded Mapbox style URL credentials'
+end
+unless view_controller.include?('URLComponents(url: styleURL, resolvingAgainstBaseURL: false)?.queryItems') &&
+       view_controller.include?('$0.name.lowercased() == "access_token"')
+  failures << 'ViewController.swift must reject access_token style URL query parameters'
+end
+unless view_controller.include?('let stylePathComponents = styleURL.pathComponents.filter { $0 != "/" }') &&
+       view_controller.include?('guard stylePathComponents.count >= 2')
+  failures << 'ViewController.swift must require owner and style path components for mapbox styles'
 end
 unless view_controller.include?('guard let styleURLHost = styleURL.host, !styleURLHost.isEmpty')
   failures << 'ViewController.swift must require a host for https style URLs'


### PR DESCRIPTION
## Summary

- reject URL usernames, passwords, and case-insensitive `access_token` query parameters in local style configuration
- require `mapbox://styles/<owner>/<style>` to identify a complete style path
- preserve blank default-style behavior and credential-free custom HTTPS providers
- extend the static contract, configuration template, documentation, and mutation evidence

## Baseline

The existing scheme and authority checks still allowed credentials to move into the style URL and accepted incomplete Mapbox style resources. The dedicated `MGLMapboxAccessToken` setting should remain the only token channel, and accepted Mapbox style URLs should identify a usable owner/style pair. This is an incremental successor to #2 and targets its remediation branch rather than the default branch.

## Improvements

- reject embedded URL usernames, passwords, and case-insensitive token query parameters
- require complete owner/style identifiers for Mapbox style URLs
- retain blank default-style behavior and credential-free custom HTTPS providers
- extend configuration, documentation, static-contract, and mutation evidence for the credential boundary

## Validation

- local and root-independent `make check`
- read-only, network-isolated Ruby 3.3 container by exact image digest
- 11 focused valid-Git-metadata mutations
- workflow YAML, three plists, seven asset JSON files, and two SVG files parsed
- vendored Mapbox executable SHA-256 verification
- Swift delimiter, corrected PCRE2 secret/token, and diff checks
- sequential plan-aware code review with no remaining findings
- hosted `check` run succeeded

## Risk

- This stacked PR depends on the remediation work in #2 and must be integrated in the correct order.
- It does not change the `MGLMapboxAccessToken` setting or restrict credential-free HTTPS style providers.
- It does not rewrite history or dismiss the existing historical secret alert.
- The legacy Xcode build is unavailable in this Linux environment, so this PR does not claim modern Xcode compatibility.

## Follow-Ups

- Integrate #2 before or together with this stacked successor so its base remains valid.
- Validate the legacy project with an appropriate Xcode and simulator environment when available.
- Address the existing historical secret alert through the repository owner's separate incident and history-management process.
- Keep any broader Mapbox configuration or platform modernization in a separately reviewed change.
