### PR TITLE
security(map): preserve attribution and telemetry controls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Kept Mapbox attribution and telemetry controls explicitly visible and removed
+  the deprecated plist flag for a separate in-app metrics setting.
+
 ## 2026-06-12
 
 - Made each location authorization transition consume its delegate-provided

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ in project keeps `DEVELOPMENT_TEAM` blank.
   `https` schemes with valid scheme-specific authorities.
 - `make check` also rejects Mapbox style URL credentials, `access_token` query
   parameters, and incomplete `mapbox://styles/<owner>/<style>` paths.
+- `make check` also keeps Mapbox attribution and telemetry controls visible and
+  rejects the deprecated plist flag that claimed a separate in-app setting.
 - GitHub Actions runs the same static `make check` baseline with Ruby 3.3,
   Node 24-compatible pinned actions, read-only permissions, disabled checkout
   credential persistence, and a timeout.
@@ -158,6 +160,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   status-driven tracking transition contract.
 - See `docs/plans/2026-06-12-mapbox-secret-token-guard.md` for the tracked
   Mapbox token formats guard and historical-alert boundary.
+- See `docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md` for the
+  required Mapbox attribution and telemetry controls.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,9 @@ Helpful reports include:
 - Tracked non-vendored files are checked for public and secret Mapbox token formats;
   the historical secret-scanning alert still requires credential-owner
   revocation evidence before resolution.
+- Mapbox attribution and telemetry controls must remain visible; the vendored
+  SDK exposes telemetry choice through its attribution info menu, so the app
+  must not hide or remove either required control.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -35,6 +35,7 @@ Priority:
 - Keep GitHub Actions running the static `make check` baseline
 - Keep the vendored Mapbox framework covered by a reviewed SHA-256 digest
 - Reject public and secret Mapbox token formats from tracked non-vendored files
+- Keep Mapbox attribution and telemetry controls visible on the map
 - Treat Swift and CocoaPods versions as legacy until documented
 
 Next priorities:

--- a/docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md
+++ b/docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md
@@ -1,0 +1,67 @@
+# Mapbox Attribution And Telemetry Controls
+
+## Status: Completed
+
+## Context
+
+The vendored Mapbox SDK documents its attribution button as the surface for
+legally required notices and telemetry settings. The app did not explicitly
+preserve that button or the Mapbox logo, while `Info.plist` retained the
+deprecated `MGLMapboxMetricsEnabledSettingShownInApp` flag even though the same
+SDK states that telemetry settings are always shown in the information menu.
+
+## Priority
+
+Attribution and telemetry choice are user-facing privacy and compliance
+boundaries. The archived app should preserve the controls supplied by its
+vendored SDK and avoid a stale configuration key that implies a separate app
+setting exists.
+
+## Objectives
+
+- Keep the Mapbox logo visible after programmatic map construction.
+- Keep the attribution button and its telemetry settings visible.
+- Remove the deprecated metrics-setting plist flag.
+- Reject source changes that hide, remove, or make either control transparent.
+- Add fail-closed documentation and completed-plan contracts.
+- Preserve map style, location authorization, annotation, and layout behavior.
+
+## Work Completed
+
+- Explicitly kept the Mapbox logo and attribution button visible during map
+  setup.
+- Removed `MGLMapboxMetricsEnabledSettingShownInApp` from the app plist.
+- Extended the dependency-free iOS checker to require both controls, reject
+  common hiding/removal patterns, and preserve the documentation contract.
+- Updated README, security, vision, and changelog guidance.
+
+## Verification
+
+- `ruby scripts/check_ios_contract.rb`
+- `make check` locally and from outside the repository root
+- focused logo, attribution, opacity, removal, deprecated-plist, documentation,
+  and plan mutations
+- workflow YAML, plist, asset JSON, README SVG, vendored-framework digest,
+  Swift delimiter, secret, artifact, and `git diff --check` audits
+- document the unavailable legacy Xcode/simulator/device boundary
+
+The iOS contract checker and full `make check` passed locally and through a
+root-independent Make invocation. The exact locally available Ruby 3.3 image
+digest also passed `make check` with a read-only checkout and disabled
+networking. All eight focused missing-control, hidden-control, opacity,
+removal, deprecated-plist, documentation, and plan-status mutation categories
+were rejected.
+
+The workflow YAML, three plists, seven asset JSON files, and both README SVG
+files parsed successfully. The vendored Mapbox executable matched
+`VENDORED_FRAMEWORKS.sha256`; Swift delimiter, high-confidence secret,
+generated-artifact, and `git diff --check` audits passed. Existing trailing
+whitespace on untouched legacy Swift lines was preserved. `xcodebuild` and
+`swiftc` are unavailable, so compile, simulator, and device validation remain
+delegated to a compatible macOS toolchain.
+
+## Scope Boundary
+
+This preserves the telemetry choice exposed by the vendored Mapbox SDK. It
+does not update the historical binary, change telemetry defaults, resolve the
+owner-only historical secret alert, or claim current App Store compliance.

--- a/engagement/Info.plist
+++ b/engagement/Info.plist
@@ -40,8 +40,6 @@
 	<string>$(MAPBOX_ACCESS_TOKEN)</string>
 	<key>MAPBOX_STYLE_URL</key>
 	<string>$(MAPBOX_STYLE_URL)</string>
-	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
-	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Helps you find your treasure on the map.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>

--- a/engagement/ViewController.swift
+++ b/engagement/ViewController.swift
@@ -38,6 +38,8 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         mapView = MGLMapView(frame: view.bounds,
                                  styleURL: styleURL)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.logoView.isHidden = false
+        mapView.attributionButton.isHidden = false
 
         mapView.setCenter(CLLocationCoordinate2D(latitude: 37.890576,
                                     longitude: -122.472104),

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -39,12 +39,14 @@ ci_plan = 'docs/plans/2026-06-10-ci-baseline.md'
 vendored_framework_plan = 'docs/plans/2026-06-10-vendored-framework-integrity.md'
 authorization_transition_plan = 'docs/plans/2026-06-12-location-authorization-transitions.md'
 mapbox_token_guard_plan = 'docs/plans/2026-06-12-mapbox-secret-token-guard.md'
+mapbox_attribution_plan = 'docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md'
 failures << "#{canonical_plan} is missing" unless File.exist?(canonical_plan)
 failures << "#{signing_team_plan} is missing" unless File.exist?(signing_team_plan)
 failures << "#{ci_plan} is missing" unless File.exist?(ci_plan)
 failures << "#{vendored_framework_plan} is missing" unless File.exist?(vendored_framework_plan)
 failures << "#{authorization_transition_plan} is missing" unless File.exist?(authorization_transition_plan)
 failures << "#{mapbox_token_guard_plan} is missing" unless File.exist?(mapbox_token_guard_plan)
+failures << "#{mapbox_attribution_plan} is missing" unless File.exist?(mapbox_attribution_plan)
 failures << 'docs/plans must contain at least one completed plan' if docs_plans.empty?
 
 docs_plans.each do |plan_path|
@@ -72,8 +74,8 @@ if info_plist.include?('NSLocationAlways') ||
    info_plist.include?('NSLocationAlwaysAndWhenInUseUsageDescription')
   failures << 'engagement/Info.plist must not request always-on location authorization'
 end
-if info_plist.include?('<key>MGLMapboxMetricsEnabledSettingShownInApp </key>')
-  failures << 'MGLMapboxMetricsEnabledSettingShownInApp key must not contain trailing whitespace'
+if info_plist.include?('MGLMapboxMetricsEnabledSettingShownInApp')
+  failures << 'engagement/Info.plist must not retain the deprecated Mapbox metrics-setting flag'
 end
 if info_plist.include?('treaure')
   failures << 'NSLocationWhenInUseUsageDescription contains a typo'
@@ -226,7 +228,7 @@ else
 end
 
 %w[README.md VISION.md SECURITY.md CHANGES.md].each do |doc_path|
-  document = File.read(doc_path)
+  document = File.read(doc_path).gsub(/\s+/, ' ')
   unless document.include?('GitHub Actions')
     failures << "#{doc_path} must document the GitHub Actions baseline"
   end
@@ -239,9 +241,21 @@ end
   unless document.include?('Mapbox style URL credentials')
     failures << "#{doc_path} must document the Mapbox style URL credential boundary"
   end
+  unless document.include?('Mapbox attribution and telemetry controls')
+    failures << "#{doc_path} must document the Mapbox attribution and telemetry controls"
+  end
 end
 
 view_controller = File.read('engagement/ViewController.swift')
+unless view_controller.include?('mapView.logoView.isHidden = false') &&
+       view_controller.include?('mapView.attributionButton.isHidden = false')
+  failures << 'ViewController.swift must keep Mapbox logo, attribution, and telemetry controls visible'
+end
+if view_controller.match?(/mapView\.(?:logoView|attributionButton)\.isHidden\s*=\s*true/) ||
+   view_controller.match?(/mapView\.(?:logoView|attributionButton)\.alpha\s*=\s*0(?:\.0)?/) ||
+   view_controller.match?(/mapView\.(?:logoView|attributionButton)\.removeFromSuperview\s*\(/)
+  failures << 'ViewController.swift must not hide or remove Mapbox attribution and telemetry controls'
+end
 if view_controller.include?('URL(string: "")')
   failures << 'ViewController.swift must not pass a blank Mapbox style URL'
 end


### PR DESCRIPTION
## Summary

Preserve the Mapbox logo and attribution control in the archived map so required notices and the vendored SDK's telemetry choice remain accessible.

## Baseline

This change is stacked on PR #3 (`lfg/scavenger-style-url-validation-20260612`) and retains the repository's archived Mapbox SDK and application behavior.

## Improvements

- Keep the Mapbox logo visible.
- Keep the attribution button visible and able to expose required notices and the vendored SDK's telemetry choice.
- Remove the obsolete plist flag that implied a separate in-app metrics setting.
- Reject hiding, removing, or making either required control transparent through the static contract.

## Validation

- `ruby scripts/check_ios_contract.rb`.
- `make check` locally and through a root-independent Make invocation.
- Digest-pinned Ruby 3.3 `make check` with a read-only checkout and networking disabled.
- Eight focused control visibility, removal, plist, documentation, and plan mutation categories.
- Workflow YAML, three plist, seven asset JSON, and two README SVG parses.
- Vendored Mapbox executable SHA-256 verification.
- Swift delimiter, secret, artifact, and `git diff --check` audits.
- The hosted check succeeded on the exact head.

## Risk

This follows the documentation shipped with the vendored framework. It does not update Mapbox, change telemetry defaults, or claim current App Store compliance. Xcode compile, simulator, and device validation were skipped because `xcodebuild` and `swiftc` are unavailable.

## Follow-Ups

- If the archived application is revived, verify the attribution and telemetry experience on an Apple toolchain and reassess it against current Mapbox and App Store requirements.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
