### PR TITLE
fix(location): gate initial authorization request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Changed initial map setup to request location authorization only from the
+  undetermined state and reuse the captured status for tracking setup.
 - Kept Mapbox attribution and telemetry controls explicitly visible and removed
   the deprecated plist flag for a separate in-app metrics setting.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ in project keeps `DEVELOPMENT_TEAM` blank.
 - `make check` also requires each location authorization transition to consume
   the delegate-provided status and stop Mapbox follow mode after denial or
   revocation.
+- `make check` also requires the app to request location authorization only
+  from the undetermined state during initial setup.
 - `make check` also rejects always-on location authorization prompts and plist
   usage-description keys.
 - `make check` also requires the prize marker to be added only once when the
@@ -162,6 +164,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   Mapbox token formats guard and historical-alert boundary.
 - See `docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md` for the
   required Mapbox attribution and telemetry controls.
+- See `docs/plans/2026-06-13-location-request-gating.md` for the initial
+  location authorization request boundary.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ Helpful reports include:
   Mapbox-scheme styles must include owner and style path components.
 - Each location authorization transition must apply the delegate-provided
   status directly and disable Mapbox follow mode when permission is unavailable.
+- Initial setup must request location authorization only from the undetermined
+  state and reuse that captured status when applying tracking behavior.
 - Tracked non-vendored files are checked for public and secret Mapbox token formats;
   the historical secret-scanning alert still requires credential-owner
   revocation evidence before resolution.

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,8 @@ Priority:
 - Enable Mapbox user tracking only after compatible authorization is available
 - Keep each location authorization transition status-driven and revoke follow
   mode when permission becomes unavailable
+- Keep initial setup able to request location authorization only from the
+  undetermined state
 - Avoid logging precise user coordinates
 - Keep Xcode workspace and scheme metadata portable across machines
 - Keep account-specific Xcode signing teams out of source control

--- a/docs/plans/2026-06-13-location-request-gating.md
+++ b/docs/plans/2026-06-13-location-request-gating.md
@@ -1,6 +1,6 @@
 # Location Authorization Request Gating
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -75,3 +75,23 @@ skip, plus focused hostile mutations and structured artifact checks.
 
 This change does not alter permission copy, request background location,
 introduce a settings deep link, or claim simulator/device validation.
+
+## Work Completed
+
+- Captured the initial `CLLocationManager` authorization status once after
+  assigning the delegate.
+- Limited `requestWhenInUseAuthorization()` to `.notDetermined` and reused the
+  captured status for initial tracking setup.
+- Extended the static iOS contract and maintained documentation to preserve the
+  request boundary and status ordering.
+
+## Verification
+
+- `ruby scripts/check_ios_contract.rb` passed.
+- `make check` passed with only the documented legacy Xcode build skip because
+  no compatible Apple toolchain is installed in the Linux environment.
+- Focused hostile mutations rejected unconditional requests, the wrong status,
+  delegate ordering loss, duplicate status reads, missing captured-status
+  application, documentation drift, and an incomplete plan status.
+- Root-independent validation and structured workflow, plist, asset JSON, and
+  README SVG parsing passed.

--- a/docs/plans/2026-06-13-location-request-gating.md
+++ b/docs/plans/2026-06-13-location-request-gating.md
@@ -1,0 +1,77 @@
+# Location Authorization Request Gating
+
+## Status: Planned
+
+## Context
+
+`ViewController.viewDidLoad()` calls `requestWhenInUseAuthorization()` on every
+load before reading the current location authorization status. The existing
+status-driven tracking helper already handles authorized, denied, restricted,
+and revoked states, but permission requests are not limited to the initial
+undetermined state.
+
+## Priority
+
+Location permission prompts should be initiated only when the user has not yet
+made a choice. Existing denied or restricted decisions should flow directly to
+tracking-disabled behavior without another request attempt.
+
+## Objectives
+
+- Read the current authorization status once during map setup.
+- Request when-in-use authorization only for `.notDetermined`.
+- Apply the same status immediately through `updateUserTracking(for:)`.
+- Preserve delegate-driven transitions after the initial setup.
+- Add fail-closed static and mutation coverage within the Linux validation
+  boundary.
+
+## Implementation Units
+
+### U1. Gate the initial authorization request
+
+**Goal:** Separate initial prompt eligibility from tracking-state application.
+
+**Files:** `engagement/ViewController.swift`
+
+**Approach:** Store the current status, request permission only when it equals
+`.notDetermined`, and pass the captured status to the existing tracking helper
+after map initialization.
+
+**Verification:** The source contains no unconditional authorization request,
+and authorized, denied, restricted, and revoked tracking behavior is unchanged.
+
+### U2. Protect lifecycle ordering
+
+**Goal:** Keep request gating and status application reviewable and mutation
+sensitive.
+
+**Dependencies:** U1
+
+**Files:** `scripts/check_ios_contract.rb`
+
+**Approach:** Require one captured status, one `.notDetermined` guard, one
+request call inside that guard, and initial tracking driven by the captured
+status rather than a second global reread.
+
+**Verification:** Focused unconditional-request, wrong-status, duplicate-read,
+missing-update, documentation, and completed-plan mutations are rejected.
+
+### U3. Synchronize privacy evidence
+
+**Goal:** Keep maintenance documentation aligned with prompt gating.
+
+**Dependencies:** U1, U2
+
+**Files:** `README.md`, `VISION.md`, `SECURITY.md`, `CHANGES.md`,
+`docs/plans/2026-06-13-location-request-gating.md`
+
+**Approach:** Document that initial permission requests are limited to the
+undetermined state and record actual static validation evidence.
+
+**Verification:** `make check` passes with only the documented legacy Xcode
+skip, plus focused hostile mutations and structured artifact checks.
+
+## Scope Boundary
+
+This change does not alter permission copy, request background location,
+introduce a settings deep link, or claim simulator/device validation.

--- a/engagement/ViewController.swift
+++ b/engagement/ViewController.swift
@@ -21,7 +21,10 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         super.viewDidLoad()
         
         locationManager.delegate = self
-        locationManager.requestWhenInUseAuthorization()
+        let initialAuthorizationStatus = CLLocationManager.authorizationStatus()
+        if initialAuthorizationStatus == .notDetermined {
+            locationManager.requestWhenInUseAuthorization()
+        }
         
         logoView = UIImageView(frame: CGRect(x: 0, y: 10, width: 55, height: 40))
         logoView.image = UIImage(named: "Logo")
@@ -47,7 +50,7 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         mapView.delegate = self
         
         view.addSubview(mapView)
-        updateUserTracking(for: CLLocationManager.authorizationStatus())
+        updateUserTracking(for: initialAuthorizationStatus)
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -40,6 +40,7 @@ vendored_framework_plan = 'docs/plans/2026-06-10-vendored-framework-integrity.md
 authorization_transition_plan = 'docs/plans/2026-06-12-location-authorization-transitions.md'
 mapbox_token_guard_plan = 'docs/plans/2026-06-12-mapbox-secret-token-guard.md'
 mapbox_attribution_plan = 'docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md'
+location_request_plan = 'docs/plans/2026-06-13-location-request-gating.md'
 failures << "#{canonical_plan} is missing" unless File.exist?(canonical_plan)
 failures << "#{signing_team_plan} is missing" unless File.exist?(signing_team_plan)
 failures << "#{ci_plan} is missing" unless File.exist?(ci_plan)
@@ -47,6 +48,7 @@ failures << "#{vendored_framework_plan} is missing" unless File.exist?(vendored_
 failures << "#{authorization_transition_plan} is missing" unless File.exist?(authorization_transition_plan)
 failures << "#{mapbox_token_guard_plan} is missing" unless File.exist?(mapbox_token_guard_plan)
 failures << "#{mapbox_attribution_plan} is missing" unless File.exist?(mapbox_attribution_plan)
+failures << "#{location_request_plan} is missing" unless File.exist?(location_request_plan)
 failures << 'docs/plans must contain at least one completed plan' if docs_plans.empty?
 
 docs_plans.each do |plan_path|
@@ -235,6 +237,9 @@ end
   unless document.include?('authorization transition')
     failures << "#{doc_path} must document the location authorization transition contract"
   end
+  unless document.include?('request location authorization only from the undetermined state')
+    failures << "#{doc_path} must document initial location authorization request gating"
+  end
   unless document.include?('Mapbox token formats')
     failures << "#{doc_path} must document the tracked Mapbox token format guard"
   end
@@ -312,11 +317,13 @@ if view_controller.match?(/print\s*\(\s*"locations\s*=/) ||
    view_controller.match?(/print\s*\([^)]*\.latitude[^)]*\.longitude/m)
   failures << 'ViewController.swift must not log precise user coordinates'
 end
-unless view_controller.include?('locationManager.delegate = self')
-  failures << 'ViewController.swift must assign the location manager delegate before requesting authorization'
-end
 unless view_controller.include?('locationManager.requestWhenInUseAuthorization()')
   failures << 'ViewController.swift must request when-in-use location authorization'
+end
+unless view_controller.scan('CLLocationManager.authorizationStatus()').length == 1 &&
+       view_controller.match?(/locationManager\.delegate = self\s*let initialAuthorizationStatus = CLLocationManager\.authorizationStatus\(\)/m) &&
+       view_controller.match?(/if initialAuthorizationStatus == \.notDetermined \{\s*locationManager\.requestWhenInUseAuthorization\(\)\s*\}/m)
+  failures << 'ViewController.swift must capture status after assigning the delegate and request authorization only from notDetermined'
 end
 if view_controller.include?('requestAlwaysAuthorization()')
   failures << 'ViewController.swift must not request always-on location authorization'
@@ -327,8 +334,8 @@ end
 unless view_controller.include?('private func updateUserTracking(for status: CLAuthorizationStatus)')
   failures << 'ViewController.swift must define a status-driven user tracking helper'
 end
-unless view_controller.include?('updateUserTracking(for: CLLocationManager.authorizationStatus())')
-  failures << 'ViewController.swift must initialize tracking from the current authorization status'
+unless view_controller.include?('updateUserTracking(for: initialAuthorizationStatus)')
+  failures << 'ViewController.swift must initialize tracking from the captured authorization status'
 end
 unless view_controller.match?(/func locationManager\(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus\)\s*\{\s*updateUserTracking\(for: status\)\s*\}/m)
   failures << 'ViewController.swift must apply the delegate-provided authorization status'


### PR DESCRIPTION
## Summary

Returning users with an existing location decision no longer trigger another authorization request when the map loads. Initial setup now captures the current status once, requests permission only while it is undetermined, and applies that same status to Mapbox tracking.

The static contract preserves delegate-before-capture ordering, the guarded request, the single status read, and captured-status tracking setup. Maintained privacy documentation and the completed implementation plan now record the same boundary.

## Baseline

This stacked change starts from `lfg/scavenger-mapbox-attribution-telemetry-20260613`. The remaining location-flow issue was that map loading could issue another authorization request even when the user had already made a location decision.

## Improvements

- Capture the current authorization status once during initial setup.
- Request permission only while authorization remains undetermined.
- Apply the captured status to Mapbox tracking while preserving delegate-before-capture ordering and the documented privacy boundary.

## Validation

- `ruby scripts/check_ios_contract.rb`
- `make check`
- root-independent `make check`
- pinned Ruby 3.3.11 read-only, network-isolated container `make check`
- eight focused hostile mutations
- workflow YAML, three app plists, seven asset JSON files, and two README SVG files parsed
- vendored Mapbox framework SHA-256 verified
- `git diff --check` and focused secret screening

The legacy Xcode build, simulator, and device checks remain unavailable because this Linux environment has neither `xcodebuild` nor `swiftc`.

## Risk

The change is limited to initial location-authorization gating and tracking setup. The principal risks are reading status more than once, requesting permission for an already-decided user, or applying a different status to tracking; the static contract and hostile mutations cover those boundaries, while runtime Apple-platform behavior remains subject to the documented toolchain limitation.

## Follow-Ups

No follow-up code work is required for this PR. Preserve the Xcode/simulator/device validation limitation in merge evidence and keep the exact-head contract check green.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
