### PR TITLE
Protect Make repository root from caller overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 RUBY ?= ruby
 RUN_LEGACY_XCODE ?= 0
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   required Mapbox attribution and telemetry controls.
 - See `docs/plans/2026-06-13-location-request-gating.md` for the initial
   location authorization request boundary.
+- See `docs/plans/2026-06-14-make-root-override-protection.md` for the
+  caller-resistant, location-independent iOS validation root.
 
 ## Contributing
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Make Root Override Protection
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -51,3 +51,25 @@ Run the static contract, all Make aliases, external hostile execution, Ruby
 - root-declaration, checker, plan-status, README-index, and evidence mutations
 - Ruby syntax, workflow YAML, protected-file, secret, artifact, and
   `git diff --check` gates
+
+## Work Completed
+
+- Protected the Makefile-derived repository root from command-line and
+  environment overrides while preserving configurable Ruby and Xcode inputs.
+- Added exact declaration, completed-evidence, and README-index contracts.
+- Preserved all Swift, Mapbox, signing, location, vendored-framework, and
+  workflow behavior boundaries.
+
+## Verification Results
+
+- `ruby scripts/check_ios_contract.rb` passed.
+- From both the checkout and an external directory, all five public Make aliases passed.
+- `make ROOT=/tmp check` passed externally while still executing the
+  repository-owned iOS contract.
+- Ruby 3.3 passed the full static gate; legacy Xcode remained explicitly
+  skipped because `RUN_LEGACY_XCODE` was not enabled on a compatible macOS host.
+- Six hostile mutations were rejected across root declaration, checker
+  expectation, plan status, README indexing, and recorded evidence.
+- Ruby syntax, workflow YAML, exact-base protected-file comparison, secret
+  screening, generated-artifact screening, and `git diff --check` passed before
+  shipping.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,53 @@
+# Make Root Override Protection
+
+## Status: Planned
+
+## Context
+
+The Makefile derives its repository root from the loaded file and uses that
+path for static iOS validation and optional legacy Xcode execution. GNU Make
+command-line variables outrank an ordinary assignment, so `make ROOT=/tmp
+check` can redirect those gates away from the checkout.
+
+## Requirements
+
+- **R1:** Prevent command-line and environment values from replacing the
+  Makefile-derived repository root.
+- **R2:** Keep `RUBY` and `RUN_LEGACY_XCODE` configurable.
+- **R3:** Require the exact protected declaration in the iOS checker.
+- **R4:** Prove every public Make alias from the checkout and an external
+  directory with a hostile `ROOT` argument.
+- **R5:** Preserve Mapbox credential, attribution, telemetry, vendored-framework,
+  signing, location, and hosted-workflow contracts.
+
+## Implementation Units
+
+### U1. Protected Root
+
+Give the repository-derived root override precedence without changing recipes,
+runtime selection, or the legacy Xcode opt-in.
+
+### U2. iOS Contract
+
+Extend `scripts/check_ios_contract.rb` to reject weakened, duplicate,
+displaced, or caller-controlled root declarations and incomplete evidence.
+
+### U3. Verification
+
+Run the static contract, all Make aliases, external hostile execution, Ruby
+3.3 validation, mutations, and integrity screening.
+
+## Scope Boundary
+
+- Do not modify Swift, projects, workspace, schemes, Pods, or signing settings.
+- Do not change location, attribution, telemetry, or Mapbox style behavior.
+- Do not add tokens, build outputs, caches, or dependency changes.
+
+## Verification
+
+- `ruby scripts/check_ios_contract.rb`
+- `make check`
+- external `make ROOT=/tmp check`
+- root-declaration, checker, plan-status, README-index, and evidence mutations
+- Ruby syntax, workflow YAML, protected-file, secret, artifact, and
+  `git diff --check` gates

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -41,6 +41,7 @@ authorization_transition_plan = 'docs/plans/2026-06-12-location-authorization-tr
 mapbox_token_guard_plan = 'docs/plans/2026-06-12-mapbox-secret-token-guard.md'
 mapbox_attribution_plan = 'docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md'
 location_request_plan = 'docs/plans/2026-06-13-location-request-gating.md'
+make_root_plan = 'docs/plans/2026-06-14-make-root-override-protection.md'
 failures << "#{canonical_plan} is missing" unless File.exist?(canonical_plan)
 failures << "#{signing_team_plan} is missing" unless File.exist?(signing_team_plan)
 failures << "#{ci_plan} is missing" unless File.exist?(ci_plan)
@@ -49,6 +50,7 @@ failures << "#{authorization_transition_plan} is missing" unless File.exist?(aut
 failures << "#{mapbox_token_guard_plan} is missing" unless File.exist?(mapbox_token_guard_plan)
 failures << "#{mapbox_attribution_plan} is missing" unless File.exist?(mapbox_attribution_plan)
 failures << "#{location_request_plan} is missing" unless File.exist?(location_request_plan)
+failures << "#{make_root_plan} is missing" unless File.exist?(make_root_plan)
 failures << 'docs/plans must contain at least one completed plan' if docs_plans.empty?
 
 docs_plans.each do |plan_path|
@@ -207,10 +209,28 @@ rescue Psych::Exception => e
 end
 
 makefile = File.read('Makefile')
+root_declaration = 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
+root_assignments = makefile.lines.map(&:chomp).grep(/\A(?:override\s+)?ROOT\s*[:?+]?=/)
+unless makefile.start_with?("#{root_declaration}\n") && root_assignments == [root_declaration]
+  failures << 'Makefile must define exactly one protected repository-derived ROOT declaration first'
+end
 unless makefile.include?('RUN_LEGACY_XCODE ?= 0') &&
        makefile.include?('xcodebuild is required when RUN_LEGACY_XCODE=1') &&
        makefile.include?('legacy Xcode build skipped')
   failures << 'Makefile must keep legacy Xcode compilation explicit and opt-in'
+end
+
+if File.exist?(make_root_plan)
+  root_plan = File.read(make_root_plan)
+  [
+    'Status: Completed',
+    '`make ROOT=/tmp check` passed',
+    'all five public Make aliases passed',
+    'Six hostile mutations were rejected',
+    'Ruby 3.3'
+  ].each do |evidence|
+    failures << "#{make_root_plan} must record verification evidence #{evidence.inspect}" unless root_plan.include?(evidence)
+  end
 end
 
 framework_manifest = 'VENDORED_FRAMEWORKS.sha256'
@@ -249,6 +269,10 @@ end
   unless document.include?('Mapbox attribution and telemetry controls')
     failures << "#{doc_path} must document the Mapbox attribution and telemetry controls"
   end
+end
+
+unless File.read('README.md').include?(make_root_plan)
+  failures << "README.md must reference #{make_root_plan}"
 end
 
 view_controller = File.read('engagement/ViewController.swift')


### PR DESCRIPTION
## Summary

- prevent callers from replacing the Makefile-derived iOS validation root
- enforce the protected declaration, completed evidence, and README index
- preserve Mapbox, signing, location, vendored-framework, and workflow contracts

## Baseline

Command-line or environment input could replace the Makefile-derived iOS validation root, allowing verification commands to resolve project files outside the checked-out repository.

## Improvements

The iOS validation root is now protected from caller overrides and enforced together with completed evidence and the README index. Existing Mapbox, signing, location, vendored-framework, and workflow contracts remain within the validated boundary.

## Validation

- all five Make aliases from root and externally with `ROOT=/tmp`
- Ruby 3.3 standalone exact-file fixture with read-only source and disabled networking
- vendored Mapbox framework digest validation
- six isolated declaration/checker/plan/README/evidence mutations rejected
- syntax, workflow, diff, secret, artifact, and protected-path integrity gates

Legacy Xcode remained on its documented explicit skip path because `RUN_LEGACY_XCODE=1` was not enabled on a compatible macOS host.

## Risk

The legacy Xcode build was not exercised and remains behind its explicit opt-in and compatible-macOS boundary. The structural checks, vendored Mapbox digest validation, and exact-head hosted check succeeded without changing signing or location behavior.

## Follow-Ups

Run the opt-in legacy Xcode path on a compatible macOS host when available. Future validation changes should preserve the protected root declaration and the existing signing, location, and vendored-framework contracts.
