### PR TITLE
feat(config): validate local demo coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Added validated local coordinate overrides for the map center and prize
+  marker, preserving pairwise reviewed demo fallbacks for invalid settings.
+
 ## 2026-06-13
 
 - Changed initial map setup to request location authorization only from the

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ components. Keep real Mapbox tokens and private style URLs out of git. Set your
 Apple development team locally in Xcode when building for a device; the checked
 in project keeps `DEVELOPMENT_TEAM` blank.
 
+The checked-in map center and prize marker are reviewed public demo fallbacks.
+To use a different event location without editing source, set all values in a
+pair through local build settings: `MAP_CENTER_LATITUDE` with
+`MAP_CENTER_LONGITUDE`, and/or `PRIZE_LATITUDE` with `PRIZE_LONGITUDE`. The app
+uses only complete, numeric, valid coordinate pairs; missing, unresolved, or
+out-of-range settings fall back to the corresponding demo coordinate. Keep
+private event locations in the ignored `MapboxSecrets.xcconfig`. These validated
+local coordinate overrides are not logged by the sample. Loading map content
+can disclose the viewed region to Mapbox under the SDK and service privacy
+terms.
+
 ## Running or Using the Project
 
 - Open `TreasureHunt.xcodeproj` in Xcode, choose the app or sample scheme, and run it on the matching simulator/device.
@@ -90,6 +101,8 @@ in project keeps `DEVELOPMENT_TEAM` blank.
   usage-description keys.
 - `make check` also requires the prize marker to be added only once when the
   view appears repeatedly.
+- `make check` also protects validated local coordinate overrides and reviewed
+  pairwise demo fallbacks for the map center and prize marker.
 - `make check` also verifies the Xcode workspace uses a relative project
   reference, the app scheme is shared, and developer-local `xcuserdata` stays
   untracked.
@@ -168,6 +181,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   location authorization request boundary.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent iOS validation root.
+- See `docs/plans/2026-06-17-configurable-demo-coordinates.md` for validated
+  local coordinate overrides and pairwise demo fallbacks.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,11 @@ Helpful reports include:
 - Mapbox attribution and telemetry controls must remain visible; the vendored
   SDK exposes telemetry choice through its attribution info menu, so the app
   must not hide or remove either required control.
+- Private event locations must use the ignored local configuration and the
+  validated local coordinate overrides. Incomplete, unresolved, non-numeric,
+  or invalid pairs must fall back together to reviewed public demo values.
+  The sample does not log those values, but loading map content can disclose the
+  viewed region to Mapbox under the SDK and service privacy terms.
 
 ## Mobile Privacy Notes
 

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,8 @@ Priority:
   mode when permission becomes unavailable
 - Keep initial setup able to request location authorization only from the
   undetermined state
+- Keep validated local coordinate overrides pairwise and preserve reviewed demo
+  fallbacks when local event values are incomplete or invalid
 - Avoid logging precise user coordinates
 - Keep Xcode workspace and scheme metadata portable across machines
 - Keep account-specific Xcode signing teams out of source control
@@ -43,7 +45,6 @@ Priority:
 Next priorities:
 
 - Add README setup notes for Mapbox credentials and Xcode version
-- Document whether coordinates are fixed, demo-only, or configurable
 - Include simulator verification notes for annotation behavior
 
 Contribution rules:

--- a/docs/plans/2026-06-17-configurable-demo-coordinates.md
+++ b/docs/plans/2026-06-17-configurable-demo-coordinates.md
@@ -1,0 +1,126 @@
+# Configurable Demo Coordinates
+
+## Status: In Progress
+
+## Context
+
+`ViewController` embeds the map center and prize location directly in source.
+Those coordinates are intentional demo values, but the current code does not
+name that boundary or provide a credential-free local configuration path for a
+different scavenger hunt. Changing the location currently requires editing and
+potentially committing source code.
+
+## Priority
+
+P1 privacy and reuse. Location values can describe a private event or proposal.
+The repository should keep reviewed public demo fallbacks while allowing local
+build configuration to replace them without source changes or silent invalid
+coordinates.
+
+## Objectives
+
+- Preserve the existing map center and prize marker as explicit demo fallbacks.
+- Read optional map-center and prize latitude/longitude pairs from Info.plist
+  build-setting placeholders.
+- Accept an override only when both components are present, resolved, numeric,
+  finite, and form a valid Core Location coordinate.
+- Fall back as a pair when either component is absent or invalid so values from
+  different locations cannot be combined.
+- Keep coordinate values out of logs and keep Mapbox credential handling
+  unchanged.
+- Add fail-closed static and mutation coverage within the Linux validation
+  boundary.
+
+## Implementation Units
+
+### U1. Add validated coordinate resolution
+
+**Goal:** Separate reviewed demo coordinates from optional local event values.
+
+**Files:** `engagement/ViewController.swift`
+
+**Approach:** Define named demo map-center and prize coordinates. Add one helper
+that reads a latitude/longitude key pair from the application bundle, rejects
+unresolved build placeholders and non-numeric values, validates the combined
+coordinate with Core Location, and otherwise returns the supplied fallback.
+Use the resolved map center during map setup and the resolved prize coordinate
+when adding the annotation.
+
+**Verification:** Existing fallback values remain exact, override resolution is
+pairwise, invalid input cannot produce a coordinate, and no coordinate is
+logged.
+
+### U2. Declare local build-setting placeholders
+
+**Goal:** Provide a source-controlled configuration boundary without storing a
+private event location.
+
+**Dependencies:** U1
+
+**Files:** `engagement/Info.plist`
+
+**Approach:** Add map-center and prize latitude/longitude keys backed by Xcode
+build-setting placeholders. Unconfigured placeholders intentionally reach the
+resolver and select the reviewed demo fallbacks.
+
+**Verification:** The plist remains valid and contains all four exact keys with
+no real private coordinate values.
+
+### U3. Protect the coordinate contract
+
+**Goal:** Make privacy and validation behavior mutation-sensitive.
+
+**Dependencies:** U1, U2
+
+**Files:** `scripts/check_ios_contract.rb`
+
+**Approach:** Require named demo fallbacks, pairwise bundle lookup, unresolved
+placeholder rejection, numeric conversion, Core Location validity checking,
+both call sites, all four plist placeholders, documentation, and completed-plan
+evidence.
+
+**Verification:** Focused mutations that remove a key, swap a call site, accept
+partial/unresolved input, skip coordinate validation, change a fallback, weaken
+guidance, or falsify completion are rejected.
+
+### U4. Synchronize privacy and setup guidance
+
+**Goal:** Make the demo-versus-local location boundary explicit to maintainers.
+
+**Dependencies:** U1, U2, U3
+
+**Files:** `README.md`, `VISION.md`, `SECURITY.md`, `CHANGES.md`,
+`docs/plans/2026-06-17-configurable-demo-coordinates.md`
+
+**Approach:** Document the four optional build settings, pairwise validation,
+reviewed demo fallback behavior, and the rule against committing private event
+coordinates.
+
+**Verification:** `make check` passes from the repository and an external
+directory, and documentation contracts fail closed when the boundary drifts.
+
+## Scope Boundary
+
+- Do not change the visible default map position or prize marker.
+- Do not add a settings UI, location upload, reverse geocoding, persistence, or
+  remote configuration.
+- Do not alter Mapbox token/style configuration, Pods, project signing, or
+  dependency versions.
+- Do not claim Xcode, simulator, or device validation from Linux.
+- Keep PR #6 and its predecessors open and preserve base-first stack ordering.
+
+## Risks
+
+- Legacy Swift syntax must remain compatible with the checked-in project era.
+- Parsing one valid component with one invalid component would create an
+  unintended hybrid location; resolution must be all-or-fallback.
+- Build-setting placeholders are strings at runtime and must not be mistaken
+  for configured coordinate values.
+
+## Work Completed
+
+- Pending implementation.
+
+## Verification
+
+- Pending implementation and validation.

--- a/docs/plans/2026-06-17-configurable-demo-coordinates.md
+++ b/docs/plans/2026-06-17-configurable-demo-coordinates.md
@@ -1,6 +1,6 @@
 # Configurable Demo Coordinates
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -57,10 +57,11 @@ private event location.
 
 **Dependencies:** U1
 
-**Files:** `engagement/Info.plist`
+**Files:** `engagement/Info.plist`, `engagement/MapboxSecrets.xcconfig.example`
 
 **Approach:** Add map-center and prize latitude/longitude keys backed by Xcode
-build-setting placeholders. Unconfigured placeholders intentionally reach the
+build-setting placeholders, and expose blank local settings in the existing
+example configuration. Unconfigured placeholders intentionally reach the
 resolver and select the reviewed demo fallbacks.
 
 **Verification:** The plist remains valid and contains all four exact keys with
@@ -119,8 +120,31 @@ directory, and documentation contracts fail closed when the boundary drifts.
 
 ## Work Completed
 
-- Pending implementation.
+- Replaced anonymous inline coordinates with named reviewed demo map-center and
+  prize fallbacks while preserving their exact values.
+- Added pairwise local build-setting resolution for map-center and prize
+  latitude/longitude values, rejecting absent, unresolved, non-string,
+  non-numeric, non-finite, and out-of-range inputs through Core Location
+  validity checks.
+- Added all four Info.plist placeholders and blank settings to the ignored local
+  configuration example without committing a private event location.
+- Extended the static checker and documentation to protect the privacy,
+  configuration, provider-disclosure, and completed-plan boundaries.
 
 ## Verification
 
-- Pending implementation and validation.
+- The focused coordinate contract passed, including Ruby syntax and structured
+  Info.plist parsing.
+- Repository and external-directory make check passed with only the documented
+  legacy Xcode build skip on Linux.
+- Nine hostile coordinate mutations were rejected across plist and example
+  keys, demo values, pairwise lookup, unresolved and non-numeric input,
+  Core Location validity, call-site wiring, and documentation.
+- Structured correctness, privacy, testing, maintainability, and project-policy
+  review found and resolved boolean plist coercion and an overstated provider
+  privacy claim; no actionable findings remain.
+- Exact diff, generated-artifact, credential, conflict, mode, binary,
+  dependency, vendored-framework, and upstream audits passed for the nine
+  intended paths.
+- A compatible Swift/Xcode toolchain is unavailable on Linux, so no compilation,
+  simulator, device, or visual-behavior result is claimed.

--- a/engagement/Info.plist
+++ b/engagement/Info.plist
@@ -40,6 +40,14 @@
 	<string>$(MAPBOX_ACCESS_TOKEN)</string>
 	<key>MAPBOX_STYLE_URL</key>
 	<string>$(MAPBOX_STYLE_URL)</string>
+	<key>MAP_CENTER_LATITUDE</key>
+	<string>$(MAP_CENTER_LATITUDE)</string>
+	<key>MAP_CENTER_LONGITUDE</key>
+	<string>$(MAP_CENTER_LONGITUDE)</string>
+	<key>PRIZE_LATITUDE</key>
+	<string>$(PRIZE_LATITUDE)</string>
+	<key>PRIZE_LONGITUDE</key>
+	<string>$(PRIZE_LONGITUDE)</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Helps you find your treasure on the map.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>

--- a/engagement/MapboxSecrets.xcconfig.example
+++ b/engagement/MapboxSecrets.xcconfig.example
@@ -2,3 +2,7 @@
 MAPBOX_ACCESS_TOKEN = replace-with-mapbox-public-token
 // Optional. Leave blank for Mapbox's default style or set a credential-free local mapbox/https style URL.
 MAPBOX_STYLE_URL =
+MAP_CENTER_LATITUDE =
+MAP_CENTER_LONGITUDE =
+PRIZE_LATITUDE =
+PRIZE_LONGITUDE =

--- a/engagement/ViewController.swift
+++ b/engagement/ViewController.swift
@@ -16,6 +16,10 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
     var mapView: MGLMapView!
     var logoView: UIImageView!
     private var didAddPrizeAnnotation = false
+    private let demoMapCenterCoordinate = CLLocationCoordinate2D(latitude: 37.890576,
+                                                                 longitude: -122.472104)
+    private let demoPrizeCoordinate = CLLocationCoordinate2D(latitude: 37.826815,
+                                                             longitude: -122.4992434)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,9 +48,10 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         mapView.logoView.isHidden = false
         mapView.attributionButton.isHidden = false
 
-        mapView.setCenter(CLLocationCoordinate2D(latitude: 37.890576,
-                                    longitude: -122.472104),
-                                    zoomLevel: 11, animated: false)
+        let mapCenterCoordinate = configuredCoordinate(latitudeKey: "MAP_CENTER_LATITUDE",
+                                                       longitudeKey: "MAP_CENTER_LONGITUDE",
+                                                       fallback: demoMapCenterCoordinate)
+        mapView.setCenter(mapCenterCoordinate, zoomLevel: 11, animated: false)
         mapView.delegate = self
         
         view.addSubview(mapView)
@@ -62,8 +67,9 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         
         // Add marker for Hawk Hill
         let hawk = MGLPointAnnotation()
-        hawk.coordinate = CLLocationCoordinate2D(latitude: ("37.826815" as NSString).doubleValue,
-                                                 longitude: ("-122.4992434" as NSString).doubleValue)
+        hawk.coordinate = configuredCoordinate(latitudeKey: "PRIZE_LATITUDE",
+                                               longitudeKey: "PRIZE_LONGITUDE",
+                                               fallback: demoPrizeCoordinate)
         hawk.title = "Prize"
         mapView.addAnnotation(hawk)
         mapView.selectAnnotation(hawk, animated: true)
@@ -148,6 +154,41 @@ class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDel
         }
 
         return styleURL
+    }
+
+    private func configuredCoordinate(latitudeKey: String,
+                                      longitudeKey: String,
+                                      fallback: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+        guard let latitude = configuredCoordinateComponent(forInfoDictionaryKey: latitudeKey),
+              let longitude = configuredCoordinateComponent(forInfoDictionaryKey: longitudeKey) else {
+            return fallback
+        }
+
+        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        guard CLLocationCoordinate2DIsValid(coordinate) else {
+            return fallback
+        }
+
+        return coordinate
+    }
+
+    private func configuredCoordinateComponent(forInfoDictionaryKey key: String) -> CLLocationDegrees? {
+        guard let rawValue = Bundle.main.object(forInfoDictionaryKey: key) else {
+            return nil
+        }
+
+        guard let stringValue = rawValue as? String else {
+            return nil
+        }
+
+        let trimmedValue = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty,
+              !trimmedValue.contains("$("),
+              let numericValue = Double(trimmedValue) else {
+            return nil
+        }
+
+        return numericValue
     }
 
     override func didReceiveMemoryWarning() {

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -42,6 +42,7 @@ mapbox_token_guard_plan = 'docs/plans/2026-06-12-mapbox-secret-token-guard.md'
 mapbox_attribution_plan = 'docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md'
 location_request_plan = 'docs/plans/2026-06-13-location-request-gating.md'
 make_root_plan = 'docs/plans/2026-06-14-make-root-override-protection.md'
+coordinate_plan = 'docs/plans/2026-06-17-configurable-demo-coordinates.md'
 failures << "#{canonical_plan} is missing" unless File.exist?(canonical_plan)
 failures << "#{signing_team_plan} is missing" unless File.exist?(signing_team_plan)
 failures << "#{ci_plan} is missing" unless File.exist?(ci_plan)
@@ -51,6 +52,7 @@ failures << "#{mapbox_token_guard_plan} is missing" unless File.exist?(mapbox_to
 failures << "#{mapbox_attribution_plan} is missing" unless File.exist?(mapbox_attribution_plan)
 failures << "#{location_request_plan} is missing" unless File.exist?(location_request_plan)
 failures << "#{make_root_plan} is missing" unless File.exist?(make_root_plan)
+failures << "#{coordinate_plan} is missing" unless File.exist?(coordinate_plan)
 failures << 'docs/plans must contain at least one completed plan' if docs_plans.empty?
 
 docs_plans.each do |plan_path|
@@ -92,6 +94,15 @@ unless File.read('engagement/MapboxSecrets.xcconfig.example').include?('replace-
 end
 unless File.read('engagement/MapboxSecrets.xcconfig.example').include?('MAPBOX_STYLE_URL =')
   failures << 'MapboxSecrets.xcconfig.example must expose optional MAPBOX_STYLE_URL configuration'
+end
+coordinate_keys = %w[MAP_CENTER_LATITUDE MAP_CENTER_LONGITUDE PRIZE_LATITUDE PRIZE_LONGITUDE]
+coordinate_keys.each do |key|
+  unless info_plist.include?("<key>#{key}</key>") && info_plist.include?("<string>$(#{key})</string>")
+    failures << "engagement/Info.plist must read #{key} from $(#{key})"
+  end
+  unless File.read('engagement/MapboxSecrets.xcconfig.example').include?("#{key} =")
+    failures << "MapboxSecrets.xcconfig.example must expose optional #{key} configuration"
+  end
 end
 
 tracked_files_output, tracked_files_error, tracked_files_status = Open3.capture3('git', 'ls-files', '-z')
@@ -233,6 +244,19 @@ if File.exist?(make_root_plan)
   end
 end
 
+if File.exist?(coordinate_plan)
+  coordinate_plan_text = File.read(coordinate_plan)
+  [
+    'Status: Completed',
+    'focused coordinate contract passed',
+    'make check passed',
+    'Nine hostile coordinate mutations were rejected',
+    'Exact diff'
+  ].each do |evidence|
+    failures << "#{coordinate_plan} must record verification evidence #{evidence.inspect}" unless coordinate_plan_text.include?(evidence)
+  end
+end
+
 framework_manifest = 'VENDORED_FRAMEWORKS.sha256'
 framework_binary = 'Pods/Mapbox-iOS-SDK/dynamic/Mapbox.framework/Mapbox'
 if File.exist?(framework_manifest)
@@ -269,13 +293,49 @@ end
   unless document.include?('Mapbox attribution and telemetry controls')
     failures << "#{doc_path} must document the Mapbox attribution and telemetry controls"
   end
+  unless document.include?('validated local coordinate overrides')
+    failures << "#{doc_path} must document validated local coordinate overrides"
+  end
 end
 
 unless File.read('README.md').include?(make_root_plan)
   failures << "README.md must reference #{make_root_plan}"
 end
+unless File.read('README.md').include?(coordinate_plan)
+  failures << "README.md must reference #{coordinate_plan}"
+end
 
 view_controller = File.read('engagement/ViewController.swift')
+unless view_controller.include?('private let demoMapCenterCoordinate = CLLocationCoordinate2D(latitude: 37.890576,') &&
+       view_controller.include?('private let demoPrizeCoordinate = CLLocationCoordinate2D(latitude: 37.826815,')
+  failures << 'ViewController.swift must keep the reviewed demo coordinate fallbacks'
+end
+unless view_controller.include?('private func configuredCoordinate(latitudeKey: String,') &&
+       view_controller.include?('longitudeKey: String,') &&
+       view_controller.include?('fallback: CLLocationCoordinate2D) -> CLLocationCoordinate2D')
+  failures << 'ViewController.swift must resolve coordinate overrides as a validated pair'
+end
+unless view_controller.include?('configuredCoordinateComponent(forInfoDictionaryKey: latitudeKey)') &&
+       view_controller.include?('configuredCoordinateComponent(forInfoDictionaryKey: longitudeKey)')
+  failures << 'ViewController.swift must require both coordinate components'
+end
+unless view_controller.include?('!trimmedValue.contains("$(")') &&
+       view_controller.include?('guard let stringValue = rawValue as? String else') &&
+       view_controller.include?('let numericValue = Double(trimmedValue)') &&
+       !view_controller.include?('rawValue as? NSNumber')
+  failures << 'ViewController.swift must reject unresolved and non-numeric coordinate settings'
+end
+unless view_controller.include?('guard CLLocationCoordinate2DIsValid(coordinate) else')
+  failures << 'ViewController.swift must reject invalid Core Location coordinates'
+end
+unless view_controller.include?('latitudeKey: "MAP_CENTER_LATITUDE"') &&
+       view_controller.include?('longitudeKey: "MAP_CENTER_LONGITUDE"') &&
+       view_controller.include?('fallback: demoMapCenterCoordinate') &&
+       view_controller.include?('latitudeKey: "PRIZE_LATITUDE"') &&
+       view_controller.include?('longitudeKey: "PRIZE_LONGITUDE"') &&
+       view_controller.include?('fallback: demoPrizeCoordinate')
+  failures << 'ViewController.swift must apply validated map-center and prize coordinate overrides'
+end
 unless view_controller.include?('mapView.logoView.isHidden = false') &&
        view_controller.include?('mapView.attributionButton.isHidden = false')
   failures << 'ViewController.swift must keep Mapbox logo, attribution, and telemetry controls visible'


### PR DESCRIPTION
## Summary

A scavenger hunt can now use private event coordinates without editing or committing Swift source. Local build settings may override the map center and prize marker, while incomplete, unresolved, non-string, non-numeric, or invalid pairs fall back together to the existing reviewed public demo locations.

The boundary remains explicit about provider privacy: the sample does not log configured coordinates, but Mapbox can observe requested map regions under its SDK and service terms.

## Baseline

- Demo map-center and prize-marker coordinates were embedded in the sample behavior, requiring source edits for private events.
- A partial or malformed local override could not be validated as one atomic coordinate pair.
- The repository contract checks did not protect the coordinate keys, fallback behavior, example configuration, or documentation wiring.
- This PR is stacked on `lfg/scavenger-make-root-override-protection-20260614` and should land after that base.

## Improvements

- Add local build-setting overrides for map-center and prize-marker coordinates through the app configuration boundary.
- Validate each coordinate pair as complete, resolved, string-backed, numeric, and geographically valid before use.
- Fall back both values in a pair to the reviewed public demo coordinates when any part of the override is invalid.
- Extend the structured iOS contract checker, example configuration, README, security guidance, vision, changelog, and implementation plan.

## Validation

- All five public Make aliases
- Repository and external-directory `make check`
- Ruby checker syntax and structured Info.plist/asset parsing
- Vendored Mapbox framework SHA-256 verification
- Nine hostile coordinate mutations
- Exact diff, artifact, credential, dependency, workflow, and upstream audits

A compatible Swift/Xcode toolchain is unavailable on Linux, so this PR does not claim compilation, simulator, device, or visual validation.

## Risk

- Incorrect private coordinate configuration intentionally falls back to public demo locations rather than using a partial pair.
- The sample does not log configured coordinates, but Mapbox can observe requested map regions under its SDK and service terms.
- Swift compilation, simulator behavior, device behavior, and visual map placement remain unverified in the current Linux environment.

## Follow-Ups

- Land this PR after its stacked base branch.
- Run the documented build, simulator/device, and visual smoke checks with a compatible Xcode toolchain before using private event coordinates.
- Implementation plan: `docs/plans/2026-06-17-configurable-demo-coordinates.md`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
