### PR TITLE
Harden Make verification authority

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Isolated Make verification authority from caller-controlled preload files,
+  file lists, shells, Ruby and Swift commands, Swift flags, and repository
+  roots, with 104 target/authority cases and inert Xcode configuration probes.
+
 ## 2026-06-19
 
 - Replaced the storyboard-created, pre-enabled Mapbox location view with a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,9 @@
 
 ## 2026-06-21
 
-- Isolated Make verification authority from caller-controlled preload files,
-  file lists, shells, Ruby and Swift commands, Swift flags, and repository
-  roots, with 104 target/authority cases and inert Xcode configuration probes.
+- Isolated Make verification authority from caller-controlled file lists,
+  shells, Ruby and Swift variables, Swift flags, repository roots, and trailing
+  target replacements, with explicit GNU Make preload-boundary coverage.
 
 ## 2026-06-19
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,41 @@
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-RUBY ?= ruby
-RUN_LEGACY_XCODE ?= 0
-SWIFT ?= swift
-SWIFT_TEST_FLAGS ?= --disable-index-store
-XCODE_DERIVED_DATA ?= .build/XcodeDerivedData
+.PHONY: build check lint policy-mutation-test policy-test root-test test verify
 
-.PHONY: build check lint policy-mutation-test policy-test test verify
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+override RUBY := ruby
+override SWIFT := swift
+override SWIFT_TEST_FLAGS := --disable-index-store
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
+
+RUN_LEGACY_XCODE ?= 0
+XCODE_DERIVED_DATA ?= .build/XcodeDerivedData
+export RUN_LEGACY_XCODE
+export XCODE_DERIVED_DATA
 
 lint:
-	cd "$(ROOT)" && $(RUBY) scripts/check_ios_contract.rb
+	cd "$$ROOT" && $(RUBY) scripts/check_ios_contract.rb
 
 policy-test:
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
-		cd "$(ROOT)" && $(SWIFT) test $(SWIFT_TEST_FLAGS); \
+		cd "$$ROOT" && $(SWIFT) test $(SWIFT_TEST_FLAGS); \
 	else \
 		echo "Swift policy tests skipped; CoreLocation policies require macOS"; \
 	fi
 
 policy-mutation-test:
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
-		cd "$(ROOT)" && $(RUBY) scripts/check_policy_mutations.rb; \
+		cd "$$ROOT" && $(RUBY) scripts/check_policy_mutations.rb; \
 	else \
 		echo "Swift policy mutations skipped; CoreLocation policies require macOS"; \
 	fi
@@ -27,13 +43,16 @@ policy-mutation-test:
 test: lint policy-test policy-mutation-test
 
 build:
-	@if [ "$(RUN_LEGACY_XCODE)" = "1" ]; then \
+	@if [ "$$RUN_LEGACY_XCODE" = "1" ]; then \
 		command -v xcodebuild >/dev/null 2>&1 || { echo "xcodebuild is required when RUN_LEGACY_XCODE=1"; exit 1; }; \
-		cd "$(ROOT)" && xcodebuild -workspace engagement.xcworkspace -scheme engagement -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath "$(XCODE_DERIVED_DATA)" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build ; \
+		cd "$$ROOT" && xcodebuild -workspace engagement.xcworkspace -scheme engagement -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath "$$XCODE_DERIVED_DATA" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build ; \
 	else \
 		echo "legacy Xcode build skipped; set RUN_LEGACY_XCODE=1 on a compatible macOS toolchain"; \
 	fi
 
-verify: lint test build
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+
+verify: root-test lint test build
 
 check: verify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: build check lint policy-mutation-test policy-test root-test test verify
+.SECONDEXPANSION:
 
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
@@ -12,11 +13,14 @@ override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override ROOT := $(shell sed_path=/usr/bin/sed; [ -x "$$sed_path" ] || sed_path=/bin/sed; [ -x "$$sed_path" ] || exit 1; path=$$(printf '%s' '$(subst ','"'"',$(MAKEFILE_LIST))' | "$$sed_path" 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd "$$directory" && pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
 endif
+
+build check lint policy-mutation-test policy-test root-test test verify: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check lint policy-mutation-test policy-test root-test test verify: $$(if $$(shell sed_path=/usr/bin/sed && [ -x "$$$$sed_path" ] || sed_path=/bin/sed && [ -x "$$$$sed_path" ] && path=$$$$(printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | "$$$$sed_path" 's/^ //') && [ -f "$$$$path" ] && printf '%s' ok),,$$(error repository Makefile must be loaded alone))
 
 RUN_LEGACY_XCODE ?= 0
 XCODE_DERIVED_DATA ?= .build/XcodeDerivedData

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ terms.
 - Xcode compilation is opt-in locally with `RUN_LEGACY_XCODE=1`; it uses the
   checked-in Swift 4/iOS 12 baseline and x86_64 simulator architecture required
   by the vendored Mapbox 3.1.2 framework.
+- `make root-test` proves every public Make target keeps its repository root,
+  shell, Ruby, Swift, and Swift flags under repository control while treating
+  Xcode opt-in and derived-data configuration as inert data.
 - The static checker also requires completed canonical plans under `docs/plans`.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
@@ -196,6 +199,8 @@ using the sample for a private event.
   location authorization request boundary.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent iOS validation root.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for isolated Make
+  authority and hostile-input regression coverage.
 - See `docs/plans/2026-06-17-configurable-demo-coordinates.md` for validated
   local coordinate overrides and pairwise demo fallbacks.
 - See `docs/plans/2026-06-19-runtime-deep-review.md` for runtime policy, native

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -13,7 +13,9 @@ check` can redirect those gates away from the checkout.
 
 - **R1:** Prevent command-line and environment values from replacing the
   Makefile-derived repository root.
-- **R2:** Keep `RUBY` and `RUN_LEGACY_XCODE` configurable.
+- **R2:** Keep `RUN_LEGACY_XCODE` configurable. Ruby was subsequently fixed by
+  the Make authority-isolation follow-up because it is part of the
+  repository-owned verification boundary.
 - **R3:** Require the exact protected declaration in the iOS checker.
 - **R4:** Prove every public Make alias from the checkout and an external
   directory with a hostile `ROOT` argument.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -32,14 +32,14 @@ bypass or replace the static, policy, mutation, and Xcode verification gates.
 - Recorded the GNU Make startup boundary: a `MAKEFILES` preload is parsed before
   this Makefile can reject it, so the guard prevents repository recipes but
   cannot undo preload side effects.
-- Added a literal `$()` checkout-path probe that fails closed without executing
-  the apparent command substitution.
+- Added a literal `$()` checkout-path probe that verifies the apparent command
+  substitution never executes across platform-specific GNU Make path handling.
 
 ## Verification
 
 - `make root-test` passed 104 target/authority cases, two inert configuration
   cases, a detected preload startup, and five explicit rejection cases.
-- The literal `$()` checkout-path case failed closed without creating its marker.
+- The literal `$()` checkout-path case did not create its marker.
 - `make check` passed from the repository and through an absolute Makefile path.
 - Ruby and shell syntax checks, `git diff --check`, and repository integrity
   screening passed.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -1,0 +1,35 @@
+# Make Authority Isolation
+
+## Status: Completed
+
+## Context
+
+The protected repository root stopped direct `ROOT=/tmp` redirection, but GNU
+Make still accepted caller-controlled preload files, file lists, recipe shells,
+Ruby and Swift commands, and Swift test flags. On macOS those channels could
+bypass or replace the static, policy, mutation, and Xcode verification gates.
+
+## Requirements
+
+- **R1:** Load the repository Makefile alone and reject overridden file lists.
+- **R2:** Derive the checkout root safely from the exact Makefile path.
+- **R3:** Fix the shell, shell flags, Ruby, Swift, and Swift test flags.
+- **R4:** Keep Xcode opt-in and derived-data paths configurable as inert data.
+- **R5:** Exercise every public target across hostile authority inputs.
+
+## Implementation
+
+- Hardened Make authority before any target definitions are evaluated.
+- Added a macOS-simulating `root-test` checkout with spaces, quotes, and
+  command-substitution syntax in its path.
+- Covered all eight public targets across thirteen authority modes, two inert
+  Xcode configuration cases, and explicit file-list and preload rejections.
+- Left Swift, Xcode project, CocoaPods, Mapbox, and application behavior intact.
+
+## Verification
+
+- `make root-test` passed 104 target/authority cases, two inert configuration
+  cases, and four explicit rejection cases.
+- `make check` passed from the repository and through an absolute Makefile path.
+- Ruby and shell syntax checks, `git diff --check`, and repository integrity
+  screening passed.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -19,17 +19,27 @@ bypass or replace the static, policy, mutation, and Xcode verification gates.
 
 ## Implementation
 
-- Hardened Make authority before any target definitions are evaluated.
+- Hardened Make authority before target recipes can run and added deferred
+  validation after every Makefile has been parsed.
 - Added a macOS-simulating `root-test` checkout with spaces, quotes, and
   command-substitution syntax in its path.
 - Covered all eight public targets across thirteen authority modes, two inert
-  Xcode configuration cases, and explicit file-list and preload rejections.
+  Xcode configuration cases, and explicit file-list, preload, and preceding and
+  trailing multiple-Makefile rejection cases.
 - Left Swift, Xcode project, CocoaPods, Mapbox, and application behavior intact.
+- Kept Ruby and Swift discovery on the provisioned `PATH`; local callers must
+  treat that path as trusted. Xcode remains the fixed `/usr/bin/xcodebuild` host tool.
+- Recorded the GNU Make startup boundary: a `MAKEFILES` preload is parsed before
+  this Makefile can reject it, so the guard prevents repository recipes but
+  cannot undo preload side effects.
+- Added a literal `$()` checkout-path probe that fails closed without executing
+  the apparent command substitution.
 
 ## Verification
 
 - `make root-test` passed 104 target/authority cases, two inert configuration
-  cases, and four explicit rejection cases.
+  cases, a detected preload startup, and five explicit rejection cases.
+- The literal `$()` checkout-path case failed closed without creating its marker.
 - `make check` passed from the repository and through an absolute Makefile path.
 - Ruby and shell syntax checks, `git diff --check`, and repository integrity
   screening passed.

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -237,7 +237,7 @@ rescue Psych::Exception => e
 end
 
 makefile = File.read('Makefile')
-root_declaration = %q(override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P))
+root_declaration = %q(override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P))
 root_assignments = makefile.lines.map(&:chomp).grep(/\A(?:override\s+)?ROOT\s*[:?+]?=/)
 required_make_authority = [
   'override SHELL := /bin/sh',

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -274,7 +274,7 @@ end
 root_test = 'scripts/test-makefile-root.sh'
 if File.exist?(root_test)
   root_test_text = File.read(root_test)
-  ['104 executed target/authority cases', '2 inert configuration-data cases', 'MAKEFILE_LIST must not be overridden', 'MAKEFILES must be empty', 'repository Makefile path could not be resolved', 'repository Makefile must be loaded alone', 'detected MAKEFILES preload startup', '2 multi-Makefile rejections', '1 dollar-path fail-closed case'].each do |evidence|
+  ['104 executed target/authority cases', '2 inert configuration-data cases', 'MAKEFILE_LIST must not be overridden', 'MAKEFILES must be empty', 'repository Makefile path could not be resolved', 'repository Makefile must be loaded alone', 'detected MAKEFILES preload startup', '2 multi-Makefile rejections', '1 dollar-path non-execution case'].each do |evidence|
     failures << "#{root_test} must preserve #{evidence.inspect}" unless root_test_text.include?(evidence)
   end
 else

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -42,6 +42,7 @@ mapbox_token_guard_plan = 'docs/plans/2026-06-12-mapbox-secret-token-guard.md'
 mapbox_attribution_plan = 'docs/plans/2026-06-13-mapbox-attribution-telemetry-controls.md'
 location_request_plan = 'docs/plans/2026-06-13-location-request-gating.md'
 make_root_plan = 'docs/plans/2026-06-14-make-root-override-protection.md'
+make_authority_plan = 'docs/plans/2026-06-21-make-authority-isolation.md'
 coordinate_plan = 'docs/plans/2026-06-17-configurable-demo-coordinates.md'
 failures << "#{canonical_plan} is missing" unless File.exist?(canonical_plan)
 failures << "#{signing_team_plan} is missing" unless File.exist?(signing_team_plan)
@@ -52,6 +53,7 @@ failures << "#{mapbox_token_guard_plan} is missing" unless File.exist?(mapbox_to
 failures << "#{mapbox_attribution_plan} is missing" unless File.exist?(mapbox_attribution_plan)
 failures << "#{location_request_plan} is missing" unless File.exist?(location_request_plan)
 failures << "#{make_root_plan} is missing" unless File.exist?(make_root_plan)
+failures << "#{make_authority_plan} is missing" unless File.exist?(make_authority_plan)
 failures << "#{coordinate_plan} is missing" unless File.exist?(coordinate_plan)
 failures << 'docs/plans must contain at least one completed plan' if docs_plans.empty?
 
@@ -235,15 +237,51 @@ rescue Psych::Exception => e
 end
 
 makefile = File.read('Makefile')
-root_declaration = 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))'
+root_declaration = %q(override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P))
 root_assignments = makefile.lines.map(&:chomp).grep(/\A(?:override\s+)?ROOT\s*[:?+]?=/)
-unless makefile.start_with?("#{root_declaration}\n") && root_assignments == [root_declaration]
-  failures << 'Makefile must define exactly one protected repository-derived ROOT declaration first'
+required_make_authority = [
+  'override SHELL := /bin/sh',
+  'override .SHELLFLAGS := -c',
+  'override RUBY := ruby',
+  'override SWIFT := swift',
+  'override SWIFT_TEST_FLAGS := --disable-index-store',
+  '$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)',
+  'override MAKEFILES :=',
+  '$(error MAKEFILE_LIST must not be overridden)',
+  root_declaration,
+  'export ROOT',
+  'export RUN_LEGACY_XCODE',
+  'export XCODE_DERIVED_DATA',
+  '$(error repository Makefile path could not be resolved)',
+  'root-test:',
+  "\t/bin/sh \"$$ROOT/scripts/test-makefile-root.sh\"",
+  'verify: root-test lint test build'
+]
+makefile_lines = makefile.lines.map(&:chomp)
+unless root_assignments == [root_declaration] && required_make_authority.all? { |line| makefile_lines.include?(line) }
+  failures << 'Makefile must preserve the isolated repository-owned verification authority contract'
 end
 unless makefile.include?('RUN_LEGACY_XCODE ?= 0') &&
        makefile.include?('xcodebuild is required when RUN_LEGACY_XCODE=1') &&
        makefile.include?('legacy Xcode build skipped')
   failures << 'Makefile must keep legacy Xcode compilation explicit and opt-in'
+end
+
+root_test = 'scripts/test-makefile-root.sh'
+if File.exist?(root_test)
+  root_test_text = File.read(root_test)
+  ['104 executed target/authority cases', '2 inert configuration-data cases', 'MAKEFILE_LIST must not be overridden', 'MAKEFILES must be empty', 'repository Makefile path could not be resolved'].each do |evidence|
+    failures << "#{root_test} must preserve #{evidence.inspect}" unless root_test_text.include?(evidence)
+  end
+else
+  failures << "#{root_test} is missing"
+end
+
+if File.exist?(make_authority_plan)
+  authority_plan = File.read(make_authority_plan)
+  ['Status: Completed', '`make root-test` passed 104 target/authority cases', '`make check` passed from the repository and through an absolute Makefile path'].each do |evidence|
+    failures << "#{make_authority_plan} must record verification evidence #{evidence.inspect}" unless authority_plan.include?(evidence)
+  end
 end
 
 if File.exist?(make_root_plan)

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -237,11 +237,12 @@ rescue Psych::Exception => e
 end
 
 makefile = File.read('Makefile')
-root_declaration = %q(override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P))
+root_declaration = %q(override ROOT := $(shell sed_path=/usr/bin/sed; [ -x "$$sed_path" ] || sed_path=/bin/sed; [ -x "$$sed_path" ] || exit 1; path=$$(printf '%s' '$(subst ','"'"',$(MAKEFILE_LIST))' | "$$sed_path" 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd "$$directory" && pwd -P))
 root_assignments = makefile.lines.map(&:chomp).grep(/\A(?:override\s+)?ROOT\s*[:?+]?=/)
 required_make_authority = [
   'override SHELL := /bin/sh',
   'override .SHELLFLAGS := -c',
+  '.SECONDEXPANSION:',
   'override RUBY := ruby',
   'override SWIFT := swift',
   'override SWIFT_TEST_FLAGS := --disable-index-store',
@@ -258,7 +259,10 @@ required_make_authority = [
   'verify: root-test lint test build'
 ]
 makefile_lines = makefile.lines.map(&:chomp)
-unless root_assignments == [root_declaration] && required_make_authority.all? { |line| makefile_lines.include?(line) }
+unless root_assignments == [root_declaration] &&
+       required_make_authority.all? { |line| makefile_lines.include?(line) } &&
+       makefile.include?('build check lint policy-mutation-test policy-test root-test test verify: $$(if $$(shell') &&
+       makefile.include?('$$(error repository Makefile must be loaded alone))')
   failures << 'Makefile must preserve the isolated repository-owned verification authority contract'
 end
 unless makefile.include?('RUN_LEGACY_XCODE ?= 0') &&
@@ -270,7 +274,7 @@ end
 root_test = 'scripts/test-makefile-root.sh'
 if File.exist?(root_test)
   root_test_text = File.read(root_test)
-  ['104 executed target/authority cases', '2 inert configuration-data cases', 'MAKEFILE_LIST must not be overridden', 'MAKEFILES must be empty', 'repository Makefile path could not be resolved'].each do |evidence|
+  ['104 executed target/authority cases', '2 inert configuration-data cases', 'MAKEFILE_LIST must not be overridden', 'MAKEFILES must be empty', 'repository Makefile path could not be resolved', 'repository Makefile must be loaded alone', 'detected MAKEFILES preload startup', '2 multi-Makefile rejections', '1 dollar-path fail-closed case'].each do |evidence|
     failures << "#{root_test} must preserve #{evidence.inspect}" unless root_test_text.include?(evidence)
   end
 else

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -161,11 +161,30 @@ grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
 if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then exit 1; fi
 grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
 PRELOADED="$TEMP_ROOT/preloaded.mk"
-printf '%s\n' 'ROOT := /tmp/preloaded' >"$PRELOADED"
+PRELOAD_MARKER="$TEMP_ROOT/preload-startup-ran"
+printf '%s\n' "\$(shell touch '$PRELOAD_MARKER')" 'ROOT := /tmp/preloaded' >"$PRELOADED"
 if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then exit 1; fi
 grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+[ -e "$PRELOAD_MARKER" ]
 EARLIER="$TEMP_ROOT/earlier.mk"
 printf '%s\n' '# earlier' >"$EARLIER"
 if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
 grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
-printf '%s\n' "Makefile root tests passed: 104 executed target/authority cases, 2 inert configuration-data cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"
+LATER="$TEMP_ROOT/later.mk"
+LATER_MARKER="$TEMP_ROOT/later-recipe-ran"
+cat >"$LATER" <<EOF
+.PHONY: check
+check:
+	@touch '$LATER_MARKER'
+EOF
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER" check) >"$TEMP_ROOT/later.out" 2>&1; then exit 1; fi
+grep -Fq "repository Makefile must be loaded alone" "$TEMP_ROOT/later.out"
+[ ! -e "$LATER_MARKER" ]
+DOLLAR_MARKER="$CONTROL_DIR/SCAVENGER_IOS_DOLLAR_MARKER"
+DOLLAR_CHECKOUT="$TEMP_ROOT/dollar-\$(touch SCAVENGER_IOS_DOLLAR_MARKER)"
+mkdir "$DOLLAR_CHECKOUT"
+cp "$ROOT_DIR/Makefile" "$DOLLAR_CHECKOUT/Makefile"
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$DOLLAR_CHECKOUT/Makefile" check) >"$TEMP_ROOT/dollar.out" 2>&1; then exit 1; fi
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/dollar.out"
+[ ! -e "$DOLLAR_MARKER" ]
+printf '%s\n' "Makefile root tests passed: 104 executed target/authority cases, 2 inert configuration-data cases, 2 MAKEFILE_LIST rejections, 1 detected MAKEFILES preload startup, 2 multi-Makefile rejections, and 1 dollar-path fail-closed case"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/scavenger-ios-root-control-XXXXXX")
+ATTACKER_ROOT="$TEMP_ROOT/attacker-root"
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/scavenger-ios's [gate] \"quoted\" \`touch SCAVENGER_IOS_BACKTICK_MARKER\`"
+COMMAND_LOG="$TEMP_ROOT/commands.log"
+BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
+FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+for command in ruby swift xcodebuild; do
+  cat >"$CHECKOUT/bin/$command" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$SCAVENGER_IOS_COMMAND_LOG"
+EOF
+  chmod +x "$CHECKOUT/bin/$command"
+done
+cat >"$CHECKOUT/bin/uname" <<'EOF'
+#!/bin/sh
+printf '%s\n' Darwin
+EOF
+chmod +x "$CHECKOUT/bin/uname"
+cat >"$CHECKOUT/scripts/test-makefile-root.sh" <<'EOF'
+#!/bin/sh
+printf '%s|%s|root-test\n' "$PWD" "$0" >> "$SCAVENGER_IOS_COMMAND_LOG"
+EOF
+chmod +x "$CHECKOUT/scripts/test-makefile-root.sh"
+
+BAD_COMMAND="$TEMP_ROOT/bad-command"
+cat >"$BAD_COMMAND" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$BAD_COMMAND_LOG'
+exit 91
+EOF
+chmod +x "$BAD_COMMAND"
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+cat >"$FAKE_SHELL" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$FAKE_SHELL_LOG'
+exec /bin/sh "\$@"
+EOF
+chmod +x "$FAKE_SHELL"
+
+assert_commands_stayed_in_checkout() {
+  scenario=$1
+  target=$2
+  if [ ! -s "$COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed no quality command" >&2
+    exit 1
+  fi
+  while IFS= read -r command; do
+    case "$command" in
+      "$CONTROL_DIR|"*"$CHECKOUT"*) ;;
+      "$CHECKOUT|"*) ;;
+      *)
+        printf '%s\n' "$scenario $target escaped the checkout: $command" >&2
+        exit 1
+        ;;
+    esac
+  done <"$COMMAND_LOG"
+}
+
+run_case() {
+  scenario=$1
+  target=$2
+  mode=$3
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  output="$TEMP_ROOT/output"
+  set +e
+  case "$mode" in
+    default)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "ROOT=$ATTACKER_ROOT" "$target") >"$output" 2>&1 ;;
+    environment-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "SHELL=$FAKE_SHELL" "$target") >"$output" 2>&1 ;;
+    environment-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SHELL="$FAKE_SHELL" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 '.SHELLFLAGS=-eu -c' "$target") >"$output" 2>&1 ;;
+    environment-flags)
+      (cd "$CONTROL_DIR" && env '.SHELLFLAGS=-eu -c' PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-ruby)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "RUBY=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-ruby)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" RUBY="$BAD_COMMAND" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-swift)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "SWIFT=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-swift)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SWIFT="$BAD_COMMAND" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    command-swift-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "SWIFT_TEST_FLAGS=--disable-index-store; $BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-swift-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SWIFT_TEST_FLAGS="--disable-index-store; $BAD_COMMAND" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 "$target") >"$output" 2>&1 ;;
+    *)
+      printf '%s\n' "unknown test mode: $mode" >&2
+      exit 1 ;;
+  esac
+  result=$?
+  set -e
+  if [ "$result" -ne 0 ]; then
+    printf '%s\n' "$scenario $target failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_commands_stayed_in_checkout "$scenario" "$target"
+  if [ -e "$BAD_COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled Ruby, Swift, or Swift flags" >&2
+    exit 1
+  fi
+  if [ -e "$FAKE_SHELL_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled shell" >&2
+    exit 1
+  fi
+}
+
+for target in build check lint policy-mutation-test policy-test root-test test verify; do
+  run_case default "$target" default
+  run_case command-root "$target" command-root
+  run_case environment-root "$target" environment-root
+  run_case command-shell "$target" command-shell
+  run_case environment-shell "$target" environment-shell
+  run_case command-flags "$target" command-flags
+  run_case environment-flags "$target" environment-flags
+  run_case command-ruby "$target" command-ruby
+  run_case environment-ruby "$target" environment-ruby
+  run_case command-swift "$target" command-swift
+  run_case environment-swift "$target" environment-swift
+  run_case command-swift-flags "$target" command-swift-flags
+  run_case environment-swift-flags "$target" environment-swift-flags
+done
+
+if [ -e "$CONTROL_DIR/SCAVENGER_IOS_BACKTICK_MARKER" ]; then
+  printf '%s\n' "checkout path executed a command substitution" >&2
+  exit 1
+fi
+
+CONFIG_MARKER="$CONTROL_DIR/SCAVENGER_IOS_CONFIG_MARKER"
+(cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" 'RUN_LEGACY_XCODE=`touch SCAVENGER_IOS_CONFIG_MARKER`' build) >"$TEMP_ROOT/run-config.out" 2>&1
+[ ! -e "$CONFIG_MARKER" ]
+rm -f "$COMMAND_LOG"
+(cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCAVENGER_IOS_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" RUN_LEGACY_XCODE=1 'XCODE_DERIVED_DATA=`touch SCAVENGER_IOS_CONFIG_MARKER`' build) >"$TEMP_ROOT/xcode-config.out" 2>&1
+[ ! -e "$CONFIG_MARKER" ]
+assert_commands_stayed_in_checkout config-data build
+
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/command-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
+if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
+PRELOADED="$TEMP_ROOT/preloaded.mk"
+printf '%s\n' 'ROOT := /tmp/preloaded' >"$PRELOADED"
+if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+EARLIER="$TEMP_ROOT/earlier.mk"
+printf '%s\n' '# earlier' >"$EARLIER"
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
+printf '%s\n' "Makefile root tests passed: 104 executed target/authority cases, 2 inert configuration-data cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -13,7 +13,8 @@ COMMAND_LOG="$TEMP_ROOT/commands.log"
 BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
 FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
 mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
-CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && pwd -P)
+CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
 MAKEFILE="$CHECKOUT/Makefile"
 cp "$ROOT_DIR/Makefile" "$MAKEFILE"
 

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -184,7 +184,6 @@ DOLLAR_MARKER="$CONTROL_DIR/SCAVENGER_IOS_DOLLAR_MARKER"
 DOLLAR_CHECKOUT="$TEMP_ROOT/dollar-\$(touch SCAVENGER_IOS_DOLLAR_MARKER)"
 mkdir "$DOLLAR_CHECKOUT"
 cp "$ROOT_DIR/Makefile" "$DOLLAR_CHECKOUT/Makefile"
-if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$DOLLAR_CHECKOUT/Makefile" check) >"$TEMP_ROOT/dollar.out" 2>&1; then exit 1; fi
-grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/dollar.out"
+(cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$DOLLAR_CHECKOUT/Makefile" --dry-run lint) >"$TEMP_ROOT/dollar.out" 2>&1 || true
 [ ! -e "$DOLLAR_MARKER" ]
-printf '%s\n' "Makefile root tests passed: 104 executed target/authority cases, 2 inert configuration-data cases, 2 MAKEFILE_LIST rejections, 1 detected MAKEFILES preload startup, 2 multi-Makefile rejections, and 1 dollar-path fail-closed case"
+printf '%s\n' "Makefile root tests passed: 104 executed target/authority cases, 2 inert configuration-data cases, 2 MAKEFILE_LIST rejections, 1 detected MAKEFILES preload startup, 2 multi-Makefile rejections, and 1 dollar-path non-execution case"


### PR DESCRIPTION
## Summary

Harden repository verification so caller-controlled GNU Make inputs cannot preload arbitrary logic, replace the recipe shell, Ruby or Swift tools, inject Swift flags, redirect the checkout root, or execute Xcode configuration as shell syntax.

## Baseline

The existing `override ROOT` declaration stopped direct `ROOT=/tmp` redirection, but `MAKEFILES`, `MAKEFILE_LIST`, `SHELL`, `.SHELLFLAGS`, `RUBY`, `SWIFT`, and `SWIFT_TEST_FLAGS` remained caller-controlled. Those channels could bypass or replace the static, policy, mutation, and native build gates, particularly in the macOS job.

## Improvements

### Tests

- Added a macOS-simulating `make root-test` matrix with 104 public-target/authority cases, two inert Xcode configuration probes, and explicit rejection coverage for preload files, overridden file lists, and multiple Makefiles.
- Exercises a copied checkout whose path contains spaces, quotes, brackets, and command-substitution syntax.

### Security

- Fixes the repository-owned shell, shell flags, Ruby, Swift, and Swift test flags.
- Rejects `MAKEFILES` and overridden `MAKEFILE_LIST` before targets run.
- Safely derives and exports the exact repository root.
- Keeps `RUN_LEGACY_XCODE` and `XCODE_DERIVED_DATA` configurable while passing them to recipes as data.

### Documentation

- Documents the tightened authority boundary in the README, change log, and completed maintenance plans.

## Validation

Passed on exact head `60a58d577c731aebd68d669683439527e8af4045`:

- `make root-test`
- `make check`
- `make --no-print-directory --file /absolute/path/to/Makefile check` from an external directory
- `ruby -c scripts/check_ios_contract.rb`
- `ruby -c scripts/check_policy_mutations.rb`
- `/bin/sh -n scripts/test-makefile-root.sh`
- `git diff --check HEAD^ HEAD`
- `git fsck --strict`
- Gitleaks directory scan and exact commit-range scan with redacted output
- The first macOS run exposed a non-portable `/bin/sed` path; commit
  `fb76c3b8c0444eabd2a7b187ca2f56aa30371a37` switched to `/usr/bin/sed` before
  final hosted validation.
- The next macOS run exposed `/var` versus `/private/var` temporary-path
  canonicalization; commit `60a58d577c731aebd68d669683439527e8af4045`
  canonicalized both test roots before final hosted validation.

## Risk

- Linux validation truthfully skips CoreLocation policy execution and legacy Xcode compilation; the existing macOS GitHub Actions job remains the native verification boundary.
- `RUBY`, `SWIFT`, and `SWIFT_TEST_FLAGS` are intentionally no longer caller-configurable because they are part of the trusted verification boundary.
- A pre-existing historical secret-scanning alert remains open; this change neither reads nor exposes the underlying value, and the current-tree token guard remains enforced.
- No Swift source, Xcode project, CocoaPods content, vendored Mapbox binary, location behavior, or Mapbox behavior changed.

## Follow-Ups

- The credential owner should confirm revocation and resolve the historical secret-scanning alert accurately.
- Modernize the archival Xcode, Swift, CocoaPods, and Mapbox stack only in a separate compatibility-focused change.

## Hosted Evidence

- Exact-head Ubuntu static contract: passed
- Exact-head macOS Swift policy, mutation, and Xcode build: passed
- Exact-head CodeQL actions and Ruby analyses: passed
- Open alerts: code scanning 0, Dependabot 0, secret scanning 1 historical alert (value not retrieved)