### PR TITLE
fix: preserve recoverable location sessions

### DIFF
--- a/PolicyTests/AppPolicyTests.swift
+++ b/PolicyTests/AppPolicyTests.swift
@@ -247,3 +247,161 @@ final class LocationTrackingPolicyTests: XCTestCase {
         ))
     }
 }
+
+final class LocationTrackingCoordinatorTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 10_000)
+
+    func testRecoverableMapboxUpdatesPreserveTrackingUntilAValidSampleArrives() {
+        var coordinator = LocationTrackingCoordinator()
+
+        let generation = coordinator.startAwaitingOwnManagerLocation()
+        XCTAssertNotNil(generation)
+        XCTAssertTrue(coordinator.acceptOwnManagerSample(generation: generation!))
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+
+        XCTAssertEqual(coordinator.handleMapboxSample(nil, now: now), .ignoredRecoverable)
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+
+        XCTAssertEqual(
+            coordinator.handleMapboxSample(makeLocation(accuracy: 25, age: 31), now: now),
+            .ignoredRecoverable
+        )
+        XCTAssertEqual(
+            coordinator.handleMapboxSample(makeLocation(accuracy: 101, age: 5), now: now),
+            .ignoredRecoverable
+        )
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+
+        XCTAssertEqual(
+            coordinator.handleMapboxSample(makeLocation(accuracy: 25, age: 5), now: now),
+            .accepted
+        )
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+    }
+
+    func testTerminalStopsDisableTrackingAndRejectLaterSamples() {
+        let reasons: [LocationTrackingStopReason] = [
+            .viewDisappeared,
+            .authorizationLost,
+            .managerFailed,
+        ]
+
+        for reason in reasons {
+            var coordinator = LocationTrackingCoordinator()
+            let generation = coordinator.startAwaitingOwnManagerLocation()!
+            XCTAssertTrue(coordinator.acceptOwnManagerSample(generation: generation))
+
+            coordinator.stop(reason: reason)
+
+            XCTAssertFalse(coordinator.isAwaitingOwnManagerLocation)
+            XCTAssertFalse(coordinator.isMapboxTrackingEnabled)
+            XCTAssertFalse(coordinator.acceptOwnManagerSample(generation: generation))
+            XCTAssertEqual(
+                coordinator.handleOwnManagerFailure(generation: generation, isRecoverable: false),
+                .ignoredInactive
+            )
+            XCTAssertEqual(
+                coordinator.handleMapboxSample(makeLocation(accuracy: 25, age: 5), now: now),
+                .ignoredStopped
+            )
+        }
+    }
+
+    func testCoordinatorRequiresAnActiveOwnManagerSessionBeforeMapboxOwnership() {
+        var coordinator = LocationTrackingCoordinator()
+
+        XCTAssertFalse(coordinator.acceptOwnManagerSample(generation: 1))
+        XCTAssertFalse(coordinator.isMapboxTrackingEnabled)
+        XCTAssertNotNil(coordinator.startAwaitingOwnManagerLocation())
+        XCTAssertNil(coordinator.startAwaitingOwnManagerLocation())
+        XCTAssertTrue(coordinator.isAwaitingOwnManagerLocation)
+    }
+
+    func testDelayedGenerationOneSuccessAndFailureCannotClaimGenerationTwo() {
+        var coordinator = LocationTrackingCoordinator()
+        let generationOne = coordinator.startAwaitingOwnManagerLocation()!
+
+        coordinator.stop(reason: .viewDisappeared)
+        let generationTwo = coordinator.startAwaitingOwnManagerLocation()!
+
+        XCTAssertGreaterThan(generationTwo, generationOne)
+        XCTAssertFalse(coordinator.acceptOwnManagerSample(generation: generationOne))
+        XCTAssertEqual(
+            coordinator.handleOwnManagerFailure(generation: generationOne, isRecoverable: false),
+            .ignoredInactive
+        )
+        XCTAssertTrue(coordinator.isAwaitingOwnManagerLocation)
+        XCTAssertTrue(coordinator.acceptOwnManagerSample(generation: generationTwo))
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+    }
+
+    func testCurrentGenerationTransfersOnlyOnceAndRejectsLaterManagerCallbacks() {
+        var coordinator = LocationTrackingCoordinator()
+        let generation = coordinator.startAwaitingOwnManagerLocation()!
+
+        XCTAssertTrue(coordinator.acceptOwnManagerSample(generation: generation))
+        XCTAssertFalse(coordinator.acceptOwnManagerSample(generation: generation))
+        XCTAssertEqual(
+            coordinator.handleOwnManagerFailure(generation: generation, isRecoverable: false),
+            .ignoredInactive
+        )
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+    }
+
+    func testLocationUnknownIsRecoverableForCurrentGeneration() {
+        var coordinator = LocationTrackingCoordinator()
+        let generation = coordinator.startAwaitingOwnManagerLocation()!
+
+        let locationUnknown = NSError(
+            domain: kCLErrorDomain,
+            code: CLError.locationUnknown.rawValue,
+            userInfo: nil
+        )
+        let denied = NSError(
+            domain: kCLErrorDomain,
+            code: CLError.denied.rawValue,
+            userInfo: nil
+        )
+
+        XCTAssertTrue(LocationManagerErrorPolicy.isRecoverable(locationUnknown))
+        XCTAssertFalse(LocationManagerErrorPolicy.isRecoverable(denied))
+
+        XCTAssertEqual(
+            coordinator.handleOwnManagerFailure(generation: generation, isRecoverable: true),
+            .ignoredRecoverable
+        )
+        XCTAssertTrue(coordinator.isAwaitingOwnManagerLocation)
+        XCTAssertTrue(coordinator.acceptOwnManagerSample(generation: generation))
+        XCTAssertTrue(coordinator.isMapboxTrackingEnabled)
+    }
+
+    func testTerminalManagerFailureStopsOnlyTheCurrentAwaitingGeneration() {
+        var coordinator = LocationTrackingCoordinator()
+        let generationOne = coordinator.startAwaitingOwnManagerLocation()!
+
+        XCTAssertEqual(
+            coordinator.handleOwnManagerFailure(generation: generationOne, isRecoverable: false),
+            .stopped
+        )
+        XCTAssertFalse(coordinator.isAwaitingOwnManagerLocation)
+        XCTAssertFalse(coordinator.isMapboxTrackingEnabled)
+
+        let generationTwo = coordinator.startAwaitingOwnManagerLocation()!
+        XCTAssertGreaterThan(generationTwo, generationOne)
+        XCTAssertEqual(
+            coordinator.handleOwnManagerFailure(generation: generationOne, isRecoverable: false),
+            .ignoredInactive
+        )
+        XCTAssertTrue(coordinator.isAwaitingOwnManagerLocation)
+    }
+
+    private func makeLocation(accuracy: CLLocationAccuracy, age: TimeInterval) -> CLLocation {
+        return CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.1, longitude: -122.2),
+            altitude: 0,
+            horizontalAccuracy: accuracy,
+            verticalAccuracy: 0,
+            timestamp: now.addingTimeInterval(-age)
+        )
+    }
+}

--- a/Sources/ScavengerHuntPolicies/AppPolicy.swift
+++ b/Sources/ScavengerHuntPolicies/AppPolicy.swift
@@ -143,6 +143,111 @@ enum LocationAuthorizationState {
     case authorized
 }
 
+enum LocationTrackingStopReason {
+    case viewDisappeared
+    case authorizationLost
+    case managerFailed
+}
+
+enum MapboxLocationSampleResult: Int {
+    case accepted
+    case ignoredRecoverable
+    case ignoredStopped
+}
+
+enum LocationManagerFailureResult: Int {
+    case ignoredInactive
+    case ignoredRecoverable
+    case stopped
+}
+
+enum LocationManagerErrorPolicy {
+    static func isRecoverable(_ error: Error) -> Bool {
+        let error = error as NSError
+        return error.domain == kCLErrorDomain &&
+            error.code == CLError.locationUnknown.rawValue
+    }
+}
+
+struct LocationTrackingCoordinator {
+    private enum State {
+        case stopped
+        case awaitingOwnManagerLocation(generation: UInt64)
+        case mapboxTracking(generation: UInt64)
+    }
+
+    private var state: State = .stopped
+    private var lastGeneration: UInt64 = 0
+
+    var isAwaitingOwnManagerLocation: Bool {
+        if case .awaitingOwnManagerLocation = state {
+            return true
+        }
+        return false
+    }
+
+    var isMapboxTrackingEnabled: Bool {
+        if case .mapboxTracking = state {
+            return true
+        }
+        return false
+    }
+
+    mutating func startAwaitingOwnManagerLocation() -> UInt64? {
+        guard case .stopped = state, lastGeneration < UInt64.max else {
+            return nil
+        }
+
+        lastGeneration += 1
+        state = .awaitingOwnManagerLocation(generation: lastGeneration)
+        return lastGeneration
+    }
+
+    mutating func acceptOwnManagerSample(generation: UInt64) -> Bool {
+        guard case .awaitingOwnManagerLocation(let activeGeneration) = state,
+              activeGeneration == generation else {
+            return false
+        }
+
+        state = .mapboxTracking(generation: generation)
+        return true
+    }
+
+    mutating func handleOwnManagerFailure(
+        generation: UInt64,
+        isRecoverable: Bool
+    ) -> LocationManagerFailureResult {
+        guard case .awaitingOwnManagerLocation(let activeGeneration) = state,
+              activeGeneration == generation else {
+            return .ignoredInactive
+        }
+        guard !isRecoverable else {
+            return .ignoredRecoverable
+        }
+
+        state = .stopped
+        return .stopped
+    }
+
+    mutating func handleMapboxSample(
+        _ location: CLLocation?,
+        now: Date = Date()
+    ) -> MapboxLocationSampleResult {
+        guard case .mapboxTracking = state else {
+            return .ignoredStopped
+        }
+        guard let location = location, LocationSamplePolicy.accepts(location, now: now) else {
+            return .ignoredRecoverable
+        }
+
+        return .accepted
+    }
+
+    mutating func stop(reason: LocationTrackingStopReason) {
+        state = .stopped
+    }
+}
+
 enum LocationTrackingPolicy {
     static func shouldRequestAuthorization(
         status: LocationAuthorizationState,

--- a/engagement/ViewController.swift
+++ b/engagement/ViewController.swift
@@ -2,13 +2,61 @@ import CoreLocation
 import Mapbox
 import UIKit
 
-final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDelegate {
-    private let locationManager = CLLocationManager()
+fileprivate protocol LocationAcquisitionSessionDelegate: class {
+    func locationAcquisitionSession(
+        _ session: LocationAcquisitionSession,
+        didUpdateLocations locations: [CLLocation]
+    )
+    func locationAcquisitionSession(
+        _ session: LocationAcquisitionSession,
+        didFailWithError error: Error
+    )
+}
+
+fileprivate final class LocationAcquisitionSession: NSObject, CLLocationManagerDelegate {
+    let generation: UInt64
+
+    private weak var delegate: LocationAcquisitionSessionDelegate?
+    private let manager: CLLocationManager
+
+    init(generation: UInt64, delegate: LocationAcquisitionSessionDelegate) {
+        self.generation = generation
+        self.delegate = delegate
+        manager = CLLocationManager()
+        super.init()
+
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.distanceFilter = kCLDistanceFilterNone
+    }
+
+    func start() {
+        manager.startUpdatingLocation()
+    }
+
+    func stop() {
+        manager.stopUpdatingLocation()
+        manager.delegate = nil
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        delegate?.locationAcquisitionSession(self, didUpdateLocations: locations)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        delegate?.locationAcquisitionSession(self, didFailWithError: error)
+    }
+}
+
+final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapViewDelegate,
+    LocationAcquisitionSessionDelegate {
+    private let authorizationManager = CLLocationManager()
+    private var locationAcquisitionSession: LocationAcquisitionSession?
     private var mapView: MGLMapView?
     private var didAddPrizeAnnotation = false
     private var hasRequestedAuthorization = false
-    private var isAwaitingLocation = false
     private var isViewVisible = false
+    private var locationTrackingCoordinator = LocationTrackingCoordinator()
 
     private let demoMapCenterCoordinate = CLLocationCoordinate2D(
         latitude: 37.890576,
@@ -23,9 +71,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapV
         super.viewDidLoad()
 
         navigationItem.titleView = UIImageView(image: UIImage(named: "Logo"))
-        locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-        locationManager.distanceFilter = kCLDistanceFilterNone
+        authorizationManager.delegate = self
         configureMap()
     }
 
@@ -44,7 +90,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapV
             hasRequestedAuthorization: hasRequestedAuthorization
         ) {
             hasRequestedAuthorization = true
-            locationManager.requestWhenInUseAuthorization()
+            authorizationManager.requestWhenInUseAuthorization()
         } else {
             synchronizeLocationTracking(for: status)
         }
@@ -54,7 +100,7 @@ final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapV
         super.viewWillDisappear(animated)
 
         isViewVisible = false
-        stopLocationTracking()
+        stopLocationTracking(reason: .viewDisappeared)
     }
 
     private func configureMap() {
@@ -115,26 +161,35 @@ final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapV
 
     private func synchronizeLocationTracking(for status: CLAuthorizationStatus) {
         let state = authorizationState(for: status)
+        if state == .restricted || state == .denied {
+            stopLocationTracking(reason: .authorizationLost)
+            return
+        }
         guard LocationTrackingPolicy.shouldStartUpdates(
             status: state,
             isViewVisible: isViewVisible,
             isMapReady: mapView != nil
         ) else {
-            stopLocationTracking()
             return
         }
 
-        guard !isAwaitingLocation else {
+        guard let generation = locationTrackingCoordinator.startAwaitingOwnManagerLocation() else {
             return
         }
 
-        isAwaitingLocation = true
-        locationManager.startUpdatingLocation()
+        let session = LocationAcquisitionSession(generation: generation, delegate: self)
+        locationAcquisitionSession = session
+        session.start()
     }
 
-    private func stopLocationTracking() {
-        isAwaitingLocation = false
-        locationManager.stopUpdatingLocation()
+    private func stopLocationTracking(reason: LocationTrackingStopReason) {
+        locationTrackingCoordinator.stop(reason: reason)
+        locationAcquisitionSession?.stop()
+        locationAcquisitionSession = nil
+        stopMapboxPresentation()
+    }
+
+    private func stopMapboxPresentation() {
         mapView?.setUserTrackingMode(.none, animated: false)
         mapView?.showsUserLocation = false
     }
@@ -166,51 +221,71 @@ final class ViewController: UIViewController, CLLocationManagerDelegate, MGLMapV
         }
     }
 
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        let status = CLLocationManager.authorizationStatus()
-        let state = authorizationState(for: status)
-        let now = Date()
-        let candidate = locations
-            .filter {
-                LocationTrackingPolicy.shouldAccept(
-                    $0,
-                    status: state,
-                    isViewVisible: isViewVisible,
-                    isAwaitingLocation: isAwaitingLocation,
-                    now: now
-                )
-            }
-            .max { $0.timestamp < $1.timestamp }
-
-        guard let location = candidate else {
-            return
-        }
-
+    fileprivate func locationAcquisitionSession(
+        _ session: LocationAcquisitionSession,
+        didUpdateLocations locations: [CLLocation]
+    ) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self,
-                  self.isViewVisible,
-                  self.isAwaitingLocation else {
+            guard let self = self else {
                 return
             }
 
-            self.isAwaitingLocation = false
-            self.locationManager.stopUpdatingLocation()
+            let status = CLLocationManager.authorizationStatus()
+            let state = self.authorizationState(for: status)
+            let now = Date()
+            let candidate = locations
+                .filter {
+                    LocationTrackingPolicy.shouldAccept(
+                        $0,
+                        status: state,
+                        isViewVisible: self.isViewVisible,
+                        isAwaitingLocation: self.locationTrackingCoordinator.isAwaitingOwnManagerLocation,
+                        now: now
+                    )
+                }
+                .max { $0.timestamp < $1.timestamp }
+
+            guard let location = candidate,
+                  self.locationAcquisitionSession === session,
+                  self.locationTrackingCoordinator.acceptOwnManagerSample(
+                      generation: session.generation
+                  ) else {
+                return
+            }
+
+            session.stop()
+            self.locationAcquisitionSession = nil
             self.mapView?.setCenter(location.coordinate, animated: false)
             self.mapView?.showsUserLocation = true
             self.mapView?.setUserTrackingMode(.follow, animated: false)
         }
     }
 
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    fileprivate func locationAcquisitionSession(
+        _ session: LocationAcquisitionSession,
+        didFailWithError error: Error
+    ) {
         DispatchQueue.main.async { [weak self] in
-            self?.stopLocationTracking()
+            guard let self = self else {
+                return
+            }
+
+            let result = self.locationTrackingCoordinator.handleOwnManagerFailure(
+                generation: session.generation,
+                isRecoverable: LocationManagerErrorPolicy.isRecoverable(error)
+            )
+            guard result == .stopped, self.locationAcquisitionSession === session else {
+                return
+            }
+
+            session.stop()
+            self.locationAcquisitionSession = nil
+            self.stopMapboxPresentation()
         }
     }
 
     func mapView(_ mapView: MGLMapView, didUpdate userLocation: MGLUserLocation?) {
-        guard let location = userLocation?.location,
-              LocationSamplePolicy.accepts(location) else {
-            stopLocationTracking()
+        guard locationTrackingCoordinator.handleMapboxSample(userLocation?.location) == .accepted else {
             return
         }
     }

--- a/scripts/check_ios_contract.rb
+++ b/scripts/check_ios_contract.rb
@@ -363,6 +363,7 @@ unless File.read('README.md').include?(coordinate_plan)
 end
 
 view_controller = File.read('engagement/ViewController.swift')
+mapbox_location_callback = view_controller[/func mapView\(_ mapView: MGLMapView, didUpdate userLocation: MGLUserLocation\?\) \{.*?^    \}/m].to_s
 policy_path = 'Sources/ScavengerHuntPolicies/AppPolicy.swift'
 policy = File.exist?(policy_path) ? File.read(policy_path) : ''
 policy_tests = File.exist?('PolicyTests/AppPolicyTests.swift') ? File.read('PolicyTests/AppPolicyTests.swift') : ''
@@ -405,7 +406,7 @@ unless view_controller.include?('navigationItem.titleView = UIImageView')
 end
 
 unless view_controller.include?('LocationTrackingPolicy.shouldRequestAuthorization') &&
-       view_controller.include?('locationManager.requestWhenInUseAuthorization()') &&
+       view_controller.include?('authorizationManager.requestWhenInUseAuthorization()') &&
        view_controller.include?('override func viewDidAppear')
   failures << 'ViewController.swift must defer and gate when-in-use authorization until the map screen is visible'
 end
@@ -413,13 +414,14 @@ if view_controller.include?('requestAlwaysAuthorization()')
   failures << 'ViewController.swift must not request always-on location authorization'
 end
 unless view_controller.include?('override func viewWillDisappear') &&
-       view_controller.include?('stopLocationTracking()') &&
-       view_controller.include?('isAwaitingLocation = false')
+       view_controller.include?('stopLocationTracking(reason: .viewDisappeared)') &&
+       view_controller.include?('locationTrackingCoordinator.stop(reason: reason)')
   failures << 'ViewController.swift must stop and invalidate location ownership when leaving the screen'
 end
 unless view_controller.include?('LocationTrackingPolicy.shouldAccept') &&
        view_controller.include?('.max { $0.timestamp < $1.timestamp }') &&
-       view_controller.include?('LocationSamplePolicy.accepts(location)')
+       view_controller.include?('locationTrackingCoordinator.handleMapboxSample') &&
+       policy.include?('LocationSamplePolicy.accepts(location, now: now)')
   failures << 'ViewController.swift must reject stale, inaccurate, or stale-session location callbacks'
 end
 unless view_controller.include?('func locationManagerDidChangeAuthorization') &&
@@ -433,6 +435,31 @@ unless view_controller.include?('mapView?.setUserTrackingMode(.none, animated: f
        view_controller.include?('mapView?.showsUserLocation = false') &&
        view_controller.include?('mapView?.setUserTrackingMode(.follow, animated: false)')
   failures << 'ViewController.swift must explicitly own Mapbox location tracking transitions'
+end
+unless view_controller.include?('fileprivate final class LocationAcquisitionSession: NSObject, CLLocationManagerDelegate') &&
+       view_controller.include?('let generation: UInt64') &&
+       view_controller.include?('manager = CLLocationManager()') &&
+       view_controller.include?('locationAcquisitionSession = session') &&
+       view_controller.scan('self.locationAcquisitionSession === session').length == 2 &&
+       view_controller.include?('acceptOwnManagerSample(') &&
+       view_controller.include?('generation: session.generation')
+  failures << 'each app-manager acquisition must have a distinct delegate owner bound to an immutable generation'
+end
+unless policy.include?('lastGeneration += 1') &&
+       policy.include?('activeGeneration == generation') &&
+       policy.include?('handleOwnManagerFailure') &&
+       view_controller.include?('LocationManagerErrorPolicy.isRecoverable(error)') &&
+       policy.include?('error.code == CLError.locationUnknown.rawValue')
+  failures << 'location ownership policy must reject inactive generations and classify locationUnknown as recoverable'
+end
+unless view_controller.include?('stopLocationTracking(reason: .authorizationLost)') &&
+       view_controller.include?('handleOwnManagerFailure(') &&
+       view_controller.include?('guard result == .stopped, self.locationAcquisitionSession === session else') &&
+       mapbox_location_callback.include?('locationTrackingCoordinator.handleMapboxSample') &&
+       !mapbox_location_callback.include?('stopLocationTracking') &&
+       !mapbox_location_callback.include?('showsUserLocation = false') &&
+       !mapbox_location_callback.include?('setUserTrackingMode(.none')
+  failures << 'recoverable Mapbox samples must preserve tracking; only lifecycle, authorization, and manager failure may stop it'
 end
 
 unless policy.include?('maximumTokenLength = 1024') &&
@@ -459,6 +486,14 @@ unless policy.include?('maximumAge: TimeInterval = 30') &&
        policy.include?('maximumHorizontalAccuracy: CLLocationAccuracy = 100')
   failures << 'AppPolicy.swift must bound location freshness, future skew, and horizontal accuracy'
 end
+unless policy.include?('struct LocationTrackingCoordinator') &&
+       policy.include?('case awaitingOwnManagerLocation') &&
+       policy.include?('case mapboxTracking') &&
+       policy.include?('return .ignoredRecoverable') &&
+       policy.include?('return .ignoredStopped') &&
+       policy.include?('LocationSamplePolicy.accepts(location, now: now)')
+  failures << 'AppPolicy.swift must coordinate own-manager handoff, recoverable Mapbox rejection, and terminal stops'
+end
 
 [
   'testCoordinateRejectsNullIslandSentinel',
@@ -468,7 +503,10 @@ end
   'testMapStyleURLRejectsFragmentsAndOversizedValues',
   'testRejectsStaleLocation',
   'testRejectsImplausiblyFutureLocation',
-  'testStaleSessionCallbackIsRejected'
+  'testStaleSessionCallbackIsRejected',
+  'testRecoverableMapboxUpdatesPreserveTrackingUntilAValidSampleArrives',
+  'testTerminalStopsDisableTrackingAndRejectLaterSamples',
+  'testCoordinatorRequiresAnActiveOwnManagerSessionBeforeMapboxOwnership'
 ].each do |test_name|
   failures << "PolicyTests must retain #{test_name}" unless policy_tests.include?(test_name)
 end

--- a/scripts/check_policy_mutations.rb
+++ b/scripts/check_policy_mutations.rb
@@ -5,6 +5,7 @@ require 'open3'
 
 ROOT = File.expand_path('..', __dir__)
 SOURCE = File.join(ROOT, 'Sources/ScavengerHuntPolicies/AppPolicy.swift')
+VIEW_CONTROLLER = File.join(ROOT, 'engagement/ViewController.swift')
 SCRATCH_PATH = File.join(ROOT, '.build')
 
 mutations = {
@@ -16,10 +17,70 @@ mutations = {
   'allow URL fragments' => ['components.fragment == nil', 'true'],
   'allow extra Mapbox path components' => ['components.count == 2', 'components.count >= 2'],
   'allow stale location samples' => ['maximumAge: TimeInterval = 30', 'maximumAge: TimeInterval = 300'],
-  'allow inaccurate location samples' => ['maximumHorizontalAccuracy: CLLocationAccuracy = 100', 'maximumHorizontalAccuracy: CLLocationAccuracy = 1000']
+  'allow inaccurate location samples' => ['maximumHorizontalAccuracy: CLLocationAccuracy = 100', 'maximumHorizontalAccuracy: CLLocationAccuracy = 1000'],
+  'start duplicate own-manager sessions' => ['guard case .stopped = state, lastGeneration < UInt64.max else {', 'guard lastGeneration < UInt64.max else {'],
+  'reuse an earlier manager generation' => ['lastGeneration += 1', '_ = lastGeneration'],
+  'accept a sample without current-generation ownership' => [
+    "guard case .awaitingOwnManagerLocation(let activeGeneration) = state,\n              activeGeneration == generation else {",
+    "guard case .awaitingOwnManagerLocation = state else {"
+  ],
+  'fail to transfer ownership to Mapbox' => ['state = .mapboxTracking(generation: generation)', 'state = .stopped'],
+  'allow an inactive generation failure to stop the current session' => [
+    "guard case .awaitingOwnManagerLocation(let activeGeneration) = state,\n              activeGeneration == generation else {\n            return .ignoredInactive",
+    "guard case .awaitingOwnManagerLocation = state else {\n            return .ignoredInactive"
+  ],
+  'make recoverable manager failures terminal' => ['guard !isRecoverable else {', 'guard isRecoverable else {'],
+  'ignore terminal manager failures' => ["state = .stopped\n        return .stopped", 'return .ignoredRecoverable'],
+  'misclassify locationUnknown as terminal' => ['error.code == CLError.locationUnknown.rawValue', 'error.code != CLError.locationUnknown.rawValue'],
+  'accept a rejected Mapbox sample' => ['return .ignoredRecoverable', 'return .accepted'],
+  'disable tracking after a rejected Mapbox sample' => [
+    "guard let location = location, LocationSamplePolicy.accepts(location, now: now) else {\n            return .ignoredRecoverable",
+    "guard let location = location, LocationSamplePolicy.accepts(location, now: now) else {\n            state = .stopped\n            return .ignoredRecoverable"
+  ],
+  'accept a Mapbox sample after a terminal stop' => ['return .ignoredStopped', 'return .accepted'],
+  'ignore terminal stops' => [
+    "mutating func stop(reason: LocationTrackingStopReason) {\n        state = .stopped",
+    "mutating func stop(reason: LocationTrackingStopReason) {\n        _ = reason"
+  ]
+}.freeze
+
+integration_mutations = {
+  'stop tracking after a recoverable Mapbox sample' => [
+    "guard locationTrackingCoordinator.handleMapboxSample(userLocation?.location) == .accepted else {\n            return",
+    "guard locationTrackingCoordinator.handleMapboxSample(userLocation?.location) == .accepted else {\n            stopLocationTracking(reason: .managerFailed)\n            return"
+  ],
+  'disable Mapbox presentation after a recoverable sample' => [
+    "guard locationTrackingCoordinator.handleMapboxSample(userLocation?.location) == .accepted else {\n            return",
+    "guard locationTrackingCoordinator.handleMapboxSample(userLocation?.location) == .accepted else {\n            mapView.showsUserLocation = false\n            return"
+  ],
+  'bypass the coordinator in the Mapbox delegate' => [
+    'locationTrackingCoordinator.handleMapboxSample(userLocation?.location)',
+    'LocationSamplePolicy.accepts(userLocation!.location!)'
+  ],
+  'skip the lifecycle terminal stop' => [
+    'stopLocationTracking(reason: .viewDisappeared)',
+    'locationTrackingCoordinator.stop(reason: .viewDisappeared)'
+  ],
+  'skip the authorization terminal stop' => [
+    'stopLocationTracking(reason: .authorizationLost)',
+    'locationTrackingCoordinator.stop(reason: .authorizationLost)'
+  ],
+  'make locationUnknown terminal in production' => [
+    'isRecoverable: LocationManagerErrorPolicy.isRecoverable(error)',
+    'isRecoverable: false'
+  ],
+  'allow a stale success session to claim the current generation' => [
+    'self.locationAcquisitionSession === session,',
+    'self.locationAcquisitionSession != nil,'
+  ],
+  'allow a stale failure session to stop the current generation' => [
+    'guard result == .stopped, self.locationAcquisitionSession === session else {',
+    'guard result == .stopped, self.locationAcquisitionSession != nil else {'
+  ]
 }.freeze
 
 original = File.read(SOURCE)
+original_view_controller = File.read(VIEW_CONTROLLER)
 
 begin
   mutations.each do |name, (before, after)|
@@ -37,8 +98,25 @@ begin
       abort "mutation survived: #{name}"
     end
   end
+
+  integration_mutations.each do |name, (before, after)|
+    unless original_view_controller.include?(before)
+      abort "integration mutation source missing for #{name}"
+    end
+
+    File.write(VIEW_CONTROLLER, original_view_controller.sub(before, after))
+    output, error, status = Open3.capture3('ruby', File.join(ROOT, 'scripts/check_ios_contract.rb'), chdir: ROOT)
+    if status.success?
+      warn output
+      warn error
+      abort "integration mutation survived: #{name}"
+    end
+    File.write(VIEW_CONTROLLER, original_view_controller)
+  end
 ensure
   File.write(SOURCE, original)
+  File.write(VIEW_CONTROLLER, original_view_controller)
 end
 
 puts "Killed #{mutations.length} policy mutations"
+puts "Killed #{integration_mutations.length} location integration mutations"


### PR DESCRIPTION
## Summary
- preserve Mapbox tracking across nil, stale, inaccurate, and otherwise recoverable user-location samples
- classify `CLError.locationUnknown` as recoverable
- bind app-owned location callbacks to per-acquisition manager/delegate generations so delayed prior-session callbacks cannot affect a restart

## Validation
- `RUN_LEGACY_XCODE=1 make check`: 27 tests, 21 policy mutations, 8 integration mutations, x86_64 Swift 4 build
- separate x86_64 `xcodebuild analyze`
- five additional hostile lifecycle sequences
- independent exact-head hostile review: GO

## Validation boundary
The vendored Mapbox 3.1.2 framework cannot run on this host's arm64 simulator; physical-device timing remains a residual boundary. The existing provider-token alert is unchanged and was not accessed beyond state metadata. Auto-merge is intentionally disabled.